### PR TITLE
Adiciona a opção de inicialização do repositório Git durante a execução do comando `novo`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ import {
     criarDiretorioAplicacao,
     criarDiretorioSeNaoExiste,
     documentar,
+    gerarRepositorioGit,
     importarModelos,
     obterTodosModelos
 } from './interface-linha-comando';
@@ -135,11 +136,31 @@ class LiquidoPontoEntrada {
                     initial: 1
                 });
 
+                const perguntaInicializarRepositorioGit = await prompts({
+                    type: 'confirm',
+                    message: 'Deseja inicializar um repositório Git?',
+                    name: 'confirmado',
+                    initial: true,
+                    onRender() {
+                        this.yesMsg = 'Sim';
+                        this.noMsg = 'não';
+                        this.yesOption = '(S/n)';
+                    }
+                });
+                const inicializarRepositorioGit =
+                    perguntaInicializarRepositorioGit.confirmado;
+
                 await copiarArquivosDeExemploParaNovoProjeto(
                     nomeProjeto,
                     perguntaTipoProjeto.tipoProjeto,
                     diretorioCompleto
                 );
+
+                await gerarRepositorioGit(
+                    inicializarRepositorioGit,
+                    diretorioCompleto
+                );
+
                 console.info(yellow(`Seu projeto foi criado com sucesso! ${diretorioCompleto}`))
             }
         }

--- a/interface-linha-comando/novo/index.ts
+++ b/interface-linha-comando/novo/index.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { async as glob } from 'fast-glob';
 import sistemaArquivos from 'fs';
 import caminho from 'path';
@@ -69,6 +70,24 @@ export async function copiarArquivosDeExemploParaNovoProjeto(
             }
         })
     );
+}
+
+export async function gerarRepositorioGit(
+    inicializarRepositorioGit: boolean,
+    diretorioProjeto: string,
+) {
+    if (inicializarRepositorioGit) {
+        execSync('git init', { cwd: diretorioProjeto });
+
+        const conteudoGitIgnore = 'node_modules/\ndist/\nbuild/\n.env\n.env.local\n.env.development\n.env.production\ncoverage/\n*.log\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.DS_Store\nThumbs.db';
+        await sistemaArquivos.promises.writeFile(
+            `${diretorioProjeto}/.gitignore`,
+            conteudoGitIgnore
+        );
+
+        execSync('git add .', { cwd: diretorioProjeto });
+        execSync('git commit -m "Commit Inicial"', { cwd: diretorioProjeto });
+    }
 }
 
 /* export function gerarProjetoPorTipoDeProjeto(tipoDeProjeto: string) {

--- a/interface-linha-comando/novo/index.ts
+++ b/interface-linha-comando/novo/index.ts
@@ -85,8 +85,12 @@ export async function gerarRepositorioGit(
             conteudoGitIgnore
         );
 
+        execSync('git config user.email "liquido@designliquido.com.br"', { cwd: diretorioProjeto });
+        execSync('git config user.name "Liquido"', { cwd: diretorioProjeto });
         execSync('git add .', { cwd: diretorioProjeto });
-        execSync('git commit -m "Commit Inicial"', { cwd: diretorioProjeto });
+        execSync('git commit -m "Versionamento Inicial"', { cwd: diretorioProjeto });
+        execSync('git config --unset user.email', { cwd: diretorioProjeto });
+        execSync('git config --unset user.name', { cwd: diretorioProjeto });
     }
 }
 

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -167,7 +167,7 @@ describe('Liquido', () => {
 
                 expect(arquivos).toContain('.gitignore');
                 expect(conteudoGitIgnore).toContain('node_modules/\ndist/\nbuild/\n.env\n.env.local\n.env.development\n.env.production\ncoverage/\n*.log\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.DS_Store\nThumbs.db');
-                expect(conteudoGitLog).toContain('Commit Inicial');
+                expect(conteudoGitLog).toContain('Versionamento Inicial');
             });
         });
     });

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -1,11 +1,13 @@
 import * as caminho from 'path';
 import sistemaArquivos from 'fs';
+import { execSync } from 'child_process';
 
 import { Liquido } from '../liquido';
 import { RetornoConfiguracaoInterface } from '../interfaces';
 import {
     criarDiretorioAplicacao,
-    copiarArquivosDeExemploParaNovoProjeto
+    copiarArquivosDeExemploParaNovoProjeto,
+    gerarRepositorioGit
 } from '../interface-linha-comando';
 
 describe('Liquido', () => {
@@ -141,6 +143,31 @@ describe('Liquido', () => {
                 );
 
                 expect(codigoConfiguracaoDelegua).toContain('ProjetoLegal');
+            });
+
+            it('O repositório Git deve ser inicializado', async () => {
+                await copiarArquivosDeExemploParaNovoProjeto(
+                    'ProjetoLegal',
+                    'api-rest',
+                    caminhoDiretorioProjeto
+                );
+
+                await gerarRepositorioGit(true, caminhoDiretorioProjeto);
+
+                const arquivos = await sistemaArquivos.promises.readdir(
+                    caminhoDiretorioProjeto
+                );
+                const conteudoGitIgnore = await sistemaArquivos
+                    .promises
+                    .readFile(`${caminhoDiretorioProjeto}/.gitignore`, 'utf-8');
+                const conteudoGitLog = execSync(
+                    'git log',
+                    { cwd: caminhoDiretorioProjeto, encoding: 'utf-8' }
+                );
+
+                expect(arquivos).toContain('.gitignore');
+                expect(conteudoGitIgnore).toContain('node_modules/\ndist/\nbuild/\n.env\n.env.local\n.env.development\n.env.production\ncoverage/\n*.log\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.DS_Store\nThumbs.db');
+                expect(conteudoGitLog).toContain('Commit Inicial');
             });
         });
     });


### PR DESCRIPTION
Este PR diz respeito a issue #52

Com essas alterações, a inicialização do repositório Git em um novo projeto que está sendo criado, é feita de forma automática caso o usuário marque a opção `Sim` durante a execução do comando `novo` quando lhe for perguntado se o repositório Git deve ser inicializado.

Closes #52