### PR TITLE
Adiciona a opção de selecionar qual gerenciador de pacotes deve ser utilizado no projeto (npm, yarn ou bun)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ import {
     copiarArquivosDeExemploParaNovoProjeto,
     criarDiretorioAplicacao,
     criarDiretorioSeNaoExiste,
+    detectarGerenciadorDePacotes,
     documentar,
     gerarRepositorioGit,
     importarModelos,
@@ -149,6 +150,25 @@ class LiquidoPontoEntrada {
                 });
                 const inicializarRepositorioGit =
                     perguntaInicializarRepositorioGit.confirmado;
+
+                const perguntaQualGerenciadorDePacotesQuerUsar = await prompts({
+                    type: 'select',
+                    name: 'gerenciadorDePacotes',
+                    message: 'Selecione o gerenciador de pacotes que você deseja utilizar',
+                    choices: [
+                        { title: 'NPM', value: 'npm' },
+                        { title: 'Yarn', value: 'yarn' },
+                        { title: 'Bun', value: 'bun' }
+                    ],
+                    initial: 1
+                });
+                const gerenciadorDePacotes =
+                    perguntaQualGerenciadorDePacotesQuerUsar.gerenciadorDePacotes;
+
+                await detectarGerenciadorDePacotes(
+                    gerenciadorDePacotes,
+                    diretorioCompleto
+                );
 
                 await copiarArquivosDeExemploParaNovoProjeto(
                     nomeProjeto,

--- a/interface-linha-comando/novo/index.ts
+++ b/interface-linha-comando/novo/index.ts
@@ -94,6 +94,29 @@ export async function gerarRepositorioGit(
     }
 }
 
+export async function detectarGerenciadorDePacotes(
+    gerenciadorDePacotes: string,
+    diretorioProjeto: string
+) {
+    switch (gerenciadorDePacotes) {
+        case 'npm': {
+            execSync('npm init -y', { cwd: diretorioProjeto });
+            execSync('npm install liquido@latest', { cwd: diretorioProjeto });
+            break;
+        }
+        case 'yarn': {
+            execSync('yarn init -y', { cwd: diretorioProjeto });
+            execSync('yarn add liquido@latest', { cwd: diretorioProjeto });
+            break;
+        }
+        case 'bun': {
+            execSync('bun init -y', { cwd: diretorioProjeto });
+            execSync('bun add liquido@latest', { cwd: diretorioProjeto });
+            break;
+        }
+    }
+}
+
 /* export function gerarProjetoPorTipoDeProjeto(tipoDeProjeto: string) {
     switch (tipoDeProjeto) {
         case 'api-rest':

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -1,14 +1,23 @@
 import * as caminho from 'path';
 import sistemaArquivos from 'fs';
-import { execSync } from 'child_process';
+import * as ChildProcess from 'child_process';
 
 import { Liquido } from '../liquido';
 import { RetornoConfiguracaoInterface } from '../interfaces';
 import {
     criarDiretorioAplicacao,
     copiarArquivosDeExemploParaNovoProjeto,
-    gerarRepositorioGit
+    gerarRepositorioGit,
+    detectarGerenciadorDePacotes
 } from '../interface-linha-comando';
+
+jest.mock('child_process', () => {
+    const original = jest.requireActual('child_process');
+    return {
+        ...original,
+        execSync: jest.fn()
+    };
+});
 
 describe('Liquido', () => {
     let liquido: Liquido;
@@ -146,6 +155,10 @@ describe('Liquido', () => {
             });
 
             it('O repositório Git deve ser inicializado', async () => {
+                (ChildProcess.execSync as jest.Mock).mockImplementation(
+                    jest.requireActual('child_process').execSync
+                );
+
                 await copiarArquivosDeExemploParaNovoProjeto(
                     'ProjetoLegal',
                     'api-rest',
@@ -160,7 +173,7 @@ describe('Liquido', () => {
                 const conteudoGitIgnore = await sistemaArquivos
                     .promises
                     .readFile(`${caminhoDiretorioProjeto}/.gitignore`, 'utf-8');
-                const conteudoGitLog = execSync(
+                const conteudoGitLog = ChildProcess.execSync(
                     'git log',
                     { cwd: caminhoDiretorioProjeto, encoding: 'utf-8' }
                 );
@@ -168,6 +181,28 @@ describe('Liquido', () => {
                 expect(arquivos).toContain('.gitignore');
                 expect(conteudoGitIgnore).toContain('node_modules/\ndist/\nbuild/\n.env\n.env.local\n.env.development\n.env.production\ncoverage/\n*.log\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.DS_Store\nThumbs.db');
                 expect(conteudoGitLog).toContain('Versionamento Inicial');
+            });
+
+            it('Deve executar os comandos do npm para inicializar o projeto', async () => {
+                jest.clearAllMocks();
+
+                (ChildProcess.execSync as jest.Mock).mockImplementation(
+                    () => Buffer.from('')
+                );
+
+                await detectarGerenciadorDePacotes(
+                    'npm',
+                    caminhoDiretorioProjeto
+                );
+
+                expect(ChildProcess.execSync).toHaveBeenCalledWith(
+                    'npm init -y',
+                    { cwd: caminhoDiretorioProjeto }
+                );
+                expect(ChildProcess.execSync).toHaveBeenCalledWith(
+                    'npm install liquido@latest',
+                    { cwd: caminhoDiretorioProjeto }
+                );
             });
         });
     });


### PR DESCRIPTION
Este PR diz respeito a issue #53

Esta implementação adiciona o suporte a seleção e inicialização do gerenciador de pacotes que o usuário preferir na criação de um novo projeto.

Closes #53