### PR TITLE
Usa o nome da pasta atual ao criar projeto com `.` ou `./`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,8 @@ import {
 } from "chalk";
 import yargs from 'yargs'
 import prompts from 'prompts';
+import { cwd } from 'process';
+import path from 'path';
 
 import {version} from './package.json'
 
@@ -110,7 +112,14 @@ class LiquidoPontoEntrada {
         }
 
         if (nomeProjeto.length > 0) {
+            const diretorioAlvo = nomeProjeto;
+
+            if (nomeProjeto === '.' || nomeProjeto === './') {
+                nomeProjeto = path.basename(cwd());
+            }
+
             console.log(green(`Iremos criar um novo projeto em Liquido chamado "${nomeProjeto}"`));
+
             const resposta = await prompts({
                 type: 'confirm',
                 message: 'Confirma?',
@@ -124,7 +133,9 @@ class LiquidoPontoEntrada {
             });
 
             if (resposta.confirmado) {
-                const diretorioCompleto = criarDiretorioAplicacao(nomeProjeto);
+                const diretorioCompleto = criarDiretorioAplicacao(
+                    diretorioAlvo
+                );
 
                 const perguntaTipoProjeto = await prompts({
                     type: 'select',

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -204,6 +204,42 @@ describe('Liquido', () => {
                     { cwd: caminhoDiretorioProjeto }
                 );
             });
+
+            it('Deve usar o nome da pasta quando o nome do projeto é criado com "." ou "./"', async () => {
+
+                const spyCwd = jest
+                    .spyOn(process, 'cwd')
+                    .mockReturnValue('/home/usuario/minha-pasta-teste');
+
+                let nomeProjetoTerminal = '.';
+                let nomeProjetoResolvido = nomeProjetoTerminal;
+
+                if (
+                    nomeProjetoTerminal === '.' ||
+                    nomeProjetoTerminal === './'
+                ) nomeProjetoResolvido = caminho.basename(process.cwd());
+
+                await copiarArquivosDeExemploParaNovoProjeto(
+                    nomeProjetoResolvido,
+                    'api-rest',
+                    caminhoDiretorioProjeto
+                );
+
+                const caminhoConfiguracaoDelegua =
+                    `${caminhoDiretorioProjeto}/configuracao.delegua`;
+
+                const codigoConfiguracaoDelegua = await sistemaArquivos
+                    .promises
+                    .readFile(
+                        caminhoConfiguracaoDelegua,
+                        'utf-8'
+                    );
+
+                expect(codigoConfiguracaoDelegua).toContain('minha-pasta-teste');
+                expect(codigoConfiguracaoDelegua).not.toContain("'.'");
+
+                spyCwd.mockRestore();
+           });
         });
     });
 });


### PR DESCRIPTION
Este PR resolve a issue #60, corrigindo o comportamento da CLI ao usar `.` ou `./` na criação de um novo projeto. Agora, a ferramenta extrai corretamente o nome da pasta atual para usar nos logs e no arquivo `configuracao.delegua`.

Closes #60