### PR TITLE
Corrige configuração 

### DIFF
--- a/fontes/infraestrutura/centro-configuracoes/configuracao-liquido.ts
+++ b/fontes/infraestrutura/centro-configuracoes/configuracao-liquido.ts
@@ -5,8 +5,8 @@ import { ConfiguracaoDados } from "./configuracao-dados";
 import { ConfiguracaoRoteador } from "./configuracao-roteador";
 
 export class ConfiguracaoLiquido extends ConfiguracaoComum {
-    arquetipo: 'rest' | 'mvc';
-    linguagem: 'delegua' | 'pitugues';
+    arquetipo: 'rest' | 'mvc' = 'rest';
+    linguagem: 'delegua' | 'pitugues' = 'delegua';
     aplicacao: ConfiguracaoAplicacao;
     autenticacao: ConfiguracaoAutenticacao;
     dados: ConfiguracaoDados;


### PR DESCRIPTION
Inicializa os atributos 'arquetipo' e 'linguagem' na classe `ConfiguracaoLiquido`, corrigindo o erro na ILC #72 
Closes #72 