### PR TITLE
Adiciona comando git para criar repositório  no Windows

### DIFF
--- a/fontes/interface-linha-comando/novo/index.ts
+++ b/fontes/interface-linha-comando/novo/index.ts
@@ -79,12 +79,14 @@ export async function gerarRepositorioGit(
 ) {
     if (inicializarRepositorioGit) {
         execSync('git init', { cwd: diretorioProjeto });
+        execSync('git config --global --add safe.directory ' + diretorioProjeto);
 
         const conteudoGitIgnore = 'node_modules/\ndist/\nbuild/\n.env\n.env.local\n.env.development\n.env.production\ncoverage/\n*.log\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.DS_Store\nThumbs.db';
         await sistemaArquivos.promises.writeFile(
             `${diretorioProjeto}/.gitignore`,
             conteudoGitIgnore
         );
+
 
         execSync('git config user.email "liquido@designliquido.com.br"', { cwd: diretorioProjeto });
         execSync('git config user.name "Liquido"', { cwd: diretorioProjeto });


### PR DESCRIPTION
# Descrição
Esta PR tem como objetivo corrigir o comando para criar repositório, cujo teste estava falhando devido a ausência do comando `git config --global --add safe.directory`, que é necessário para o correto funcionamento dos comandos relacionados ao Git, em ambiente Windows. 
## Alterações
- Adição do comando `git config --global --add safe.directory ' + diretorioProjeto` no processo de criação de repositório, garantindo que o ambiente esteja configurado corretamente para evitar erros relacionados ao Git.

## Ganhos
- Correção do teste de criação de repositório, permitindo que ele seja executado com sucesso em ambientes Windows, melhorando a confiabilidade dos testes e a experiência do usuário.

fix #75
