### PR TITLE
Correção do comando yarn init

### DIFF
--- a/fontes/interface-linha-comando/novo/index.ts
+++ b/fontes/interface-linha-comando/novo/index.ts
@@ -108,7 +108,7 @@ export async function detectarGerenciadorDePacotes(
             break;
         }
         case 'yarn': {
-            execSync('yarn init', { cwd: diretorioProjeto });
+            execSync('yarn init -2 -y', { cwd: diretorioProjeto });
             execSync('yarn add liquido@latest', { cwd: diretorioProjeto });
             break;
         }

--- a/fontes/interface-linha-comando/novo/index.ts
+++ b/fontes/interface-linha-comando/novo/index.ts
@@ -108,7 +108,7 @@ export async function detectarGerenciadorDePacotes(
             break;
         }
         case 'yarn': {
-            execSync('yarn init -2 -y', { cwd: diretorioProjeto });
+            execSync('yarn init -y', { cwd: diretorioProjeto });
             execSync('yarn add liquido@latest', { cwd: diretorioProjeto });
             break;
         }

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -337,6 +337,31 @@ describe('Liquido', () => {
                 );
             });
 
+
+            it('Deve executar os comandos do yarn para inicializar o projeto', async () => {
+                jest.clearAllMocks();
+
+                (ChildProcess.execSync as jest.Mock).mockImplementation(
+                    () => Buffer.from('')
+                );
+
+                await detectarGerenciadorDePacotes(
+                    'yarn',
+                    caminhoDiretorioProjeto
+                );
+
+                expect(ChildProcess.execSync).toHaveBeenCalledWith(
+                    'yarn init -2 -y',
+                    { cwd: caminhoDiretorioProjeto }
+                );
+                expect(ChildProcess.execSync).toHaveBeenCalledWith(
+                    'yarn add liquido@latest',
+                    { cwd: caminhoDiretorioProjeto }
+                );
+    
+            });
+        
+
             it('Deve usar o nome da pasta quando o nome do projeto é criado com "." ou "./"', async () => {
 
                 const spyCwd = jest

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -351,7 +351,7 @@ describe('Liquido', () => {
                 );
 
                 expect(ChildProcess.execSync).toHaveBeenCalledWith(
-                    'yarn init -2 -y',
+                    'yarn init -y',
                     { cwd: caminhoDiretorioProjeto }
                 );
                 expect(ChildProcess.execSync).toHaveBeenCalledWith(


### PR DESCRIPTION
# Descrição
Esta PR tem como objetivo corrigir o comando para incializar o projeto usando o `yarn`.
## Alterações
- Comando atualizado para `yarn init -y` para criar o projeto com o Yarn `-y` para aceitar as configurações padrão, evitando erros relacionados a prompts de configuração.
## Ganhos
Correção do comando de inicialização do projeto, eliminando o erro relacionado ao `yarn init` e permitindo que o projeto seja configurado corretamente com o Yarn .
fix #77
