### PR TITLE
atualiza configuracao comum

### DIFF
--- a/fontes/infraestrutura/centro-configuracoes/configuracao-comum.ts
+++ b/fontes/infraestrutura/centro-configuracoes/configuracao-comum.ts
@@ -7,7 +7,7 @@ export abstract class ConfiguracaoComum implements AspectoConfiguracaoInterface 
     definirValor(instancia: AspectoConfiguracaoInterface, caminho: string[], valor: any): void {
         caminho.shift();
         if (caminho.length === 1) {
-            if (!instancia.hasOwnProperty(caminho[0])) {
+            if (!(caminho[0] in instancia)) {
                 throw new ErroConfiguracao(`Propriedade ${caminho[0]} não existe em ${instancia.constructor.name}.`);
             }
 
@@ -16,7 +16,7 @@ export abstract class ConfiguracaoComum implements AspectoConfiguracaoInterface 
         }
 
         const proximaPropriedade = caminho[0];
-        if (!instancia.hasOwnProperty(proximaPropriedade)) {
+        if (!(proximaPropriedade in instancia)) {
             throw new ErroConfiguracao(`Propriedade ${proximaPropriedade} não existe em ${instancia.constructor.name}.`);
         }
 


### PR DESCRIPTION
# Descrição
Esta PR tem como objetivo corrigir o erro de configuração relacionado a propriedade linguagem do projeto, que estava causando falhas devido a alteração no acesso a essa propriedade. 
## Alterações
- Substituição do método `hasOwnProperty` por `in` para verificar a existência da propriedade `linguagem` no objeto de configuração do projeto.
## Ganhos
- Correção do erro de configuração, permitindo que o projeto acesse corretamente a propriedade `linguagem` e evitando falhas relacionadas a essa questão.
fix #81
