### PR TITLE
Corrige erro 404 e adiciona verificação para user

### DIFF
--- a/fontes/infraestrutura/roteador/roteador.ts
+++ b/fontes/infraestrutura/roteador/roteador.ts
@@ -217,7 +217,10 @@ export class Roteador implements RoteadorInterface {
                         id: usuario.id
                     };
                     const token = jwt.encode(payload, devolverVariavelAmbiente('chaveSecreta') as string);
-                    users.find((u) => u.id === usuario.id).token = token;
+                    const user = users.find((u) => u.id === usuario.id);
+                    if (user) {
+                        user.token = token;
+                    }
                     return res.json({ token });
                 } else {
                     res.sendStatus(401);

--- a/fontes/liquido.ts
+++ b/fontes/liquido.ts
@@ -322,7 +322,8 @@ export class Liquido implements LiquidoInterface {
             .replace(new RegExp(`\\${caminho.sep}`, 'g'), '/')
             .replace(new RegExp(`/$`, 'g'), '')
             .replace(new RegExp(`\\[(.+)\\]`, 'g'), ':$1');
-        return rotaResolvida;
+
+        return rotaResolvida === '' ? '/' : rotaResolvida;
     }
 
     async analisarArquivo(arquivo: string): Promise<Declaracao[] | null> {

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -51,7 +51,7 @@ describe('Liquido', () => {
         });
 
         expect(expected.length).toBeGreaterThanOrEqual(2);
-        expect(expected[0]).toBe('');
+        expect(expected[0]).toBe('/');
         expect(expected[1]).toBe('/middlewares');
     });
 
@@ -86,7 +86,7 @@ describe('Liquido', () => {
             await instanciaTeste.iniciar();
 
             expect(instanciaTeste.arquivosPitugues.length).toBeGreaterThan(0);
-            expect(instanciaTeste.rotasPitugues).toContain('');
+            expect(instanciaTeste.rotasPitugues).toContain('/');
 
             jest.restoreAllMocks();
         });
@@ -142,7 +142,7 @@ describe('Liquido', () => {
             );
             const rota = liquido.resolverCaminhoRota(arquivo, 'pitugues');
 
-            expect(rota).toBe('');
+            expect(rota).toBe('/');
         });
 
         it('Deve remover extensão .pitu do caminho', () => {

--- a/testes/middlewares-integracao.test.ts
+++ b/testes/middlewares-integracao.test.ts
@@ -113,7 +113,7 @@ describe('Testes de Integração - Middlewares', () => {
             const arquivo = caminho.join(__dirname, 'exemplos', 'rotas', 'inicial.delegua');
             const rota = liquido.resolverCaminhoRota(arquivo, 'delegua');
 
-            expect(rota).toBe('');
+            expect(rota).toBe('/');
         });
 
         it('Deve resolver caminho de arquivo em subdiretório', () => {


### PR DESCRIPTION
# Descrição
Esta PR tem como objetivo corrigir o erro 404 e adicionar uma verificação para garantir que o objeto `user` exista antes de acessar suas propriedades, evitando erros relacionados a `undefined`. 
## Alterações
- Função `resolverCaminhoRota` foi atualizada para converter o caminho da rota para `/` quando for resolvido para `''`.
- Adiciona verificação para garantir que `user` exista antes de acessar suas propriedades, evitando erros relacionados a `undefined`.

## Ganhos
- Correção do erro 404, permitindo que o projeto acesse corretamente as rotas e evitando falhas relacionadas a essa questão.
fix #80
