### PR TITLE
Evita arquivos desnecessários ao usar Bun

### DIFF
--- a/fontes/interface-linha-comando/novo/index.ts
+++ b/fontes/interface-linha-comando/novo/index.ts
@@ -101,6 +101,8 @@ export async function detectarGerenciadorDePacotes(
     gerenciadorDePacotes: string,
     diretorioProjeto: string
 ) {
+    const caminhoPackageJson = caminho.join(diretorioProjeto, 'package.json');
+
     switch (gerenciadorDePacotes) {
         case 'npm': {
             execSync('npm init -y', { cwd: diretorioProjeto });
@@ -113,7 +115,20 @@ export async function detectarGerenciadorDePacotes(
             break;
         }
         case 'bun': {
-            execSync('bun init -y', { cwd: diretorioProjeto });
+            if (!sistemaArquivos.existsSync(caminhoPackageJson)) {
+                const conteudoPackageJson = {
+                    name: caminho.basename(diretorioProjeto),
+                    version: '1.0.0',
+                    private: true,
+                    dependencies: {}
+                };
+
+                await sistemaArquivos.promises.writeFile(
+                    caminhoPackageJson,
+                    JSON.stringify(conteudoPackageJson, null, 2) + '\n'
+                );
+            }
+
             execSync('bun add liquido@latest', { cwd: diretorioProjeto });
             break;
         }

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -370,6 +370,70 @@ describe('Liquido', () => {
                 );
     
             });
+
+            it('Deve inicializar projeto com Bun sem criar arquivos desnecessários', async () => {
+                jest.clearAllMocks();
+                const caminhoDiretorioBun = caminho.join(
+                    process.cwd(),
+                    'teste-comando-novo-bun'
+                );
+
+                (ChildProcess.execSync as jest.Mock).mockImplementation(
+                    () => Buffer.from('')
+                );
+
+                await sistemaArquivos.promises.rm(
+                    caminhoDiretorioBun,
+                    { recursive: true, force: true }
+                );
+                await sistemaArquivos.promises.mkdir(caminhoDiretorioBun);
+
+                try {
+                    await detectarGerenciadorDePacotes(
+                        'bun',
+                        caminhoDiretorioBun
+                    );
+
+                    const conteudoPackageJson = JSON.parse(
+                        await sistemaArquivos.promises.readFile(
+                            `${caminhoDiretorioBun}/package.json`,
+                            'utf-8'
+                        )
+                    );
+
+                    expect(ChildProcess.execSync).not.toHaveBeenCalledWith(
+                        'bun init -y',
+                        { cwd: caminhoDiretorioBun }
+                    );
+                    expect(ChildProcess.execSync).toHaveBeenCalledWith(
+                        'bun add liquido@latest',
+                        { cwd: caminhoDiretorioBun }
+                    );
+                    expect(conteudoPackageJson).toMatchObject({
+                        name: 'teste-comando-novo-bun',
+                        version: '1.0.0',
+                        private: true,
+                        dependencies: {}
+                    });
+                    expect(conteudoPackageJson).not.toHaveProperty(
+                        'peerDependencies.typescript'
+                    );
+                    expect(
+                        sistemaArquivos.existsSync(`${caminhoDiretorioBun}/tsconfig.json`)
+                    ).toBeFalsy();
+                    expect(
+                        sistemaArquivos.existsSync(`${caminhoDiretorioBun}/index.ts`)
+                    ).toBeFalsy();
+                    expect(
+                        sistemaArquivos.existsSync(`${caminhoDiretorioBun}/README.md`)
+                    ).toBeFalsy();
+                } finally {
+                    await sistemaArquivos.promises.rm(
+                        caminhoDiretorioBun,
+                        { recursive: true, force: true }
+                    );
+                }
+            });
         
 
             it('Deve usar o nome da pasta quando o nome do projeto é criado com "." ou "./"', async () => {


### PR DESCRIPTION
## Resumo
- Evita a execução de `bun init -y` ao selecionar Bun como gerenciador de pacotes.
- Cria um `package.json` mínimo quando ele ainda não existe e mantém a instalação com `bun add liquido@latest`.
- Adiciona uma regressão garantindo que `tsconfig.json`, `index.ts`, `README.md` e `peerDependencies.typescript` não sejam criados por esse caminho.

## Validação
- `node_modules\.bin\jest.cmd --runTestsByPath testes/liquido.test.ts --runInBand`
- `node_modules\.bin\tsc.cmd --noEmit --pretty false`

Closes #71
