### PR TITLE
Altera caminho de criação do arquivo css.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Se uma imagem com o nome `teste.png` é colocada dentro do diretório `publico`,
 
 #### Conversões automáticas para diretório estático
 
-Ao inicializar, Liquido verifica um diretório `estilos`. Havendo arquivos FolEs nele (extensão `.foles`), cada arquivo é automaticamente convertido para CSS e salvo em um diretório dentro do diretório estático definido na configuração chamado `css`. Ou seja, um arquivo `teste.foles` é salvo em `/publico/css/teste.css` e pode ser acessado por http://localhost:3000/css/teste.css. 
+Ao inicializar, Liquido verifica um diretório `estilos`. Havendo arquivos FolEs nele (extensão `.foles`), cada arquivo é automaticamente convertido para CSS e salvo diretamente no diretório estático definido na configuração. Ou seja, um arquivo `teste.foles` é salvo em `/publico/teste.css` e pode ser acessado por http://localhost:3000/teste.css. 
 
 ### Padrões de Aplicação
 

--- a/fontes/infraestrutura/centro-configuracoes/configuracao-roteador.ts
+++ b/fontes/infraestrutura/centro-configuracoes/configuracao-roteador.ts
@@ -25,8 +25,6 @@ export class ConfiguracaoRoteador extends ConfiguracaoComum {
         roteador.ativarDesativarHelmet(this.helmet);
         roteador.ativarDesativarMorgan(this.morgan);
         roteador.ativarDesativarPassport(this.passport);
-        if (this.diretorioEstatico) {
-            roteador.configurarArquivosEstaticos(this.diretorioEstatico);
-        }
+        // Nota: configurarArquivosEstaticos é chamado em liquido.ts com caminho absoluto
     }
 }

--- a/fontes/liquido.ts
+++ b/fontes/liquido.ts
@@ -323,15 +323,15 @@ export class Liquido implements LiquidoInterface {
     escreverEstilos() {
         const arquivosEstilos = this.descobrirEstilos();
 
-        if (!sistemaDeArquivos.existsSync(`./${this.diretorioEstatico}/css`)) {
-            sistemaDeArquivos.mkdirSync(`./${this.diretorioEstatico}/css`, { recursive: true });
+        if (!sistemaDeArquivos.existsSync(`./${this.diretorioEstatico}`)) {
+            sistemaDeArquivos.mkdirSync(`./${this.diretorioEstatico}`, { recursive: true });
         }
 
         for (const arquivo of arquivosEstilos) {
             const teste = this.foles.converterParaCss(arquivo);
             const arquivoDestino = caminho.join(
                 process.cwd(),
-                `./${this.diretorioEstatico}/css`,
+                `./${this.diretorioEstatico}`,
                 arquivo.replace('estilos', '').replace('.foles', '.css')
             );
             sistemaDeArquivos.writeFile(arquivoDestino, teste, (erro) => {

--- a/fontes/liquido.ts
+++ b/fontes/liquido.ts
@@ -132,7 +132,9 @@ export class Liquido implements LiquidoInterface {
             }
         }
 
-        this.roteador.configurarArquivosEstaticos(this.diretorioEstatico);
+        const diretorioEstatico = this.centroConfiguracoes?.liquido?.roteador?.diretorioEstatico || this.diretorioEstatico;
+        const caminhoAbsolutoEstatico = caminho.join(this.diretorioBase, diretorioEstatico);
+        this.roteador.configurarArquivosEstaticos(caminhoAbsolutoEstatico);
         this.roteador.iniciarMiddlewares();
         await this.importarArquivosRotas();
 

--- a/testes/infraestrutura/centro-configuracoes.test.ts
+++ b/testes/infraestrutura/centro-configuracoes.test.ts
@@ -186,7 +186,8 @@ describe('Testes das classes de configuração', () => {
             expect(roteador.ativarDesativarHelmet).toHaveBeenCalledWith(true);
             expect(roteador.ativarDesativarMorgan).toHaveBeenCalledWith(false);
             expect(roteador.ativarDesativarPassport).toHaveBeenCalledWith(false);
-            expect(roteador.configurarArquivosEstaticos).toHaveBeenCalledWith('publico');
+            // configurarArquivosEstaticos agora é chamado em liquido.ts com caminho absoluto
+            expect(roteador.configurarArquivosEstaticos).not.toHaveBeenCalled();
         });
 
         it('não deve chamar configurarArquivosEstaticos quando diretorioEstatico for vazio', () => {


### PR DESCRIPTION
# Descrição
Esta PR tem como objetivo corrigir o erro `Refused to apply style from 'http://localhost:3000/estilo.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled` que ocorre em rotas que retornam páginas LMHT. O problema está relacionado à forma como o Express lida com rotas que retornam páginas LMHT, resultando em um erro 500 ao tentar acessar essas rotas.
## Alterações
- Arquivos alterados para trabalhar com o caminho absoluto do diretório, em vez do caminho relativo,  garantindo que o arquivo CSS seja servido corretamente.
## Ganhos
Com essa alteração, o erro de MIME type será resolvido, permitindo que as páginas LMHT sejam carregadas corretamente com o estilo aplicado.
Fix #89