### PR TITLE
44: implementa recarregamento automático de rotas nativo

### DIFF
--- a/fontes/index.ts
+++ b/fontes/index.ts
@@ -9,7 +9,8 @@ import {
 } from "chalk";
 import yargs from 'yargs'
 import prompts from 'prompts';
-import { cwd } from 'process';
+import { spawn } from 'child_process';
+import { argv, cwd, env, execPath } from 'process';
 import path from 'path';
 import fs from 'fs';
 
@@ -43,6 +44,9 @@ class LiquidoPontoEntrada {
     }
 
     mostrarLogo() {
+    if (process.env.LIQUIDO_OBSERVANDO === '1') {
+        return;
+    }
         console.log(blue(this.logo + '\n'))
     }
 
@@ -281,7 +285,47 @@ class LiquidoPontoEntrada {
         }
     }
 
+    private resolverCaminhosObservados(): string[] {
+        return ['rotas', 'visoes', 'estilos']
+            .map((diretorio) => path.join(process.cwd(), diretorio))
+            .filter((diretorio) => fs.existsSync(diretorio));
+    }
+
+    private iniciarServidorComObservacao(): void {
+        const caminhosObservados = this.resolverCaminhosObservados();
+
+        if (caminhosObservados.length === 0) {
+            console.warn(yellow('Nenhum diretório de rotas, visões ou estilos encontrado para observar.'));
+        }
+
+        const argumentos = [
+            '--watch',
+            ...caminhosObservados.map((diretorio) => `--watch-path=${diretorio}`),
+            argv[1],
+            ...argv.slice(2)
+        ];
+
+        console.info(blue('Observando mudanças em rotas, visões e estilos...'));
+
+        const processo = spawn(execPath, argumentos, {
+            stdio: 'inherit',
+            env: {
+                ...env,
+                LIQUIDO_OBSERVANDO: '1'
+            }
+        });
+
+        processo.on('exit', (codigo) => {
+            process.exit(codigo ?? 0);
+        });
+    }
+
     comandoServidor() {
+        if (env.LIQUIDO_OBSERVANDO !== '1') {
+            this.iniciarServidorComObservacao();
+            return;
+        }
+
         const liquido = new Liquido(process.cwd());
         liquido.iniciar();
     }
@@ -303,7 +347,7 @@ class LiquidoPontoEntrada {
         .usage('Uso: $0 <comando> [opções]')
         .help('ajuda')
         .alias('ajuda', '?')
-        .command(['*', 'servidor'], 'Serve o diretório local como uma aplicação para a internet.', {}, this.comandoServidor)
+        .command(['*', 'servidor'], 'Serve o diretório local como uma aplicação para a internet.', {}, this.comandoServidor.bind(this))
         .command('documentar', 'Lê o projeto e gera uma documentação OpenAPI correspondente', {}, this.comandoDocumentar)
         .command('novo [nome]', 'Inicia uma nova aplicação pré-configurada para funcionar com Liquido.', { nome: { type: 'string' as const, default: '' } }, this.comandoNovo)
         .command('gerar [modelo]', 'Gera controlador e visão correspondentes ao nome do modelo passado por parâmetro. O modelo deve ter um arquivo .delegua correspondente no diretório "modelos".', { modelo: { type: 'string' as const, default: '' } }, this.comandoGerar)


### PR DESCRIPTION
## O que foi alterado

* **Modo de Observação Nativo**: O comando `servidor` agora inicia um subprocesso utilizando o `spawn` do Node.js passando as flags `--watch` e `--watch-path`.
* **Caminhos Monitorados**: Mapeamento e monitoramento automático dos diretórios `rotas`, `visoes` e `estilos` (caso existam no projeto).
* **Controle do Logotipo**: Ajuste no método `mostrarLogo()` para evitar que o logotipo do framework seja exibido repetidamente quando o processo filho for reiniciado.

## Motivo da mudança

Substitui a necessidade de ferramentas externas como o `nodemon` para recarregar a aplicação. Agora, o salvamento de qualquer arquivo de rota ou estilo reinicia o servidor em milissegundos de forma nativa (Node v18+), melhorando a experiência de desenvolvimento sem adicionar novas dependências.

## Resultado

Ao rodar `yarn liquido` ou `npm run liquido`, o servidor entra em modo de recarregamento automático por padrão. Qualquer alteração nos arquivos monitorados reinicia o processo instantaneamente no console, sem travar a porta 3000.

<img width="538" height="281" alt="" src="https://github.com/user-attachments/assets/b5549315-8ffb-4bff-ab44-f4034b070d51" />
<img width="529" height="91" alt="server-restarting" src="https://github.com/user-attachments/assets/d69260bb-56ec-4113-9dc6-2d3858a82f9c" />

## Issue relacionada

Resolve #44