### PR TITLE
Corrige scaffold MVC vazio: adiciona rota, visão e estilo iniciais (#…

### DIFF
--- a/fontes/interface-linha-comando/exemplos/delegua/mvc/estilos/principal.foles
+++ b/fontes/interface-linha-comando/exemplos/delegua/mvc/estilos/principal.foles
@@ -1,0 +1,11 @@
+corpo {
+    cor-fundo: #f4f6f8;
+    cor: #22303c;
+    margem: 48px;
+    tamanho-fonte: 18px;
+    altura-linha: 1.6;
+}
+
+titulo1 {
+    cor: #0e3a5f;
+}

--- a/fontes/interface-linha-comando/exemplos/delegua/mvc/rotas/inicial.delegua
+++ b/fontes/interface-linha-comando/exemplos/delegua/mvc/rotas/inicial.delegua
@@ -1,0 +1,5 @@
+liquido.rotaGet(funcao(requisicao, resposta) {
+    resposta.lmht({
+        "nome": "mundo"
+    })
+})

--- a/fontes/interface-linha-comando/exemplos/delegua/mvc/visoes/inicial.lmht
+++ b/fontes/interface-linha-comando/exemplos/delegua/mvc/visoes/inicial.lmht
@@ -1,0 +1,16 @@
+<lmht>
+    <cabeça>
+        <meta nome="viewport" conteudo="width=device-width, initial-scale=1.0" />
+        <recurso tipo="stylesheet" destino="/css/principal.css" />
+        <titulo>Bem-vindo ao Liquido</titulo>
+    </cabeça>
+    <corpo>
+        <titulo1>Olá, {{nome}}!</titulo1>
+        <p>Sua aplicação MVC em Liquido está no ar.</p>
+        <p>Para começar:</p>
+        <p>— A rota desta página fica em rotas/inicial.delegua;</p>
+        <p>— Esta visão fica em visoes/inicial.lmht;</p>
+        <p>— O estilo fica em estilos/principal.foles, transpilado automaticamente para publico/css/principal.css.</p>
+        <p>Qualquer alteração nesses diretórios recarrega a aplicação automaticamente. Boa jornada!</p>
+    </corpo>
+</lmht>

--- a/fontes/interface-linha-comando/exemplos/pitugues/mvc/estilos/principal.foles
+++ b/fontes/interface-linha-comando/exemplos/pitugues/mvc/estilos/principal.foles
@@ -1,0 +1,11 @@
+corpo {
+    cor-fundo: #f4f6f8;
+    cor: #22303c;
+    margem: 48px;
+    tamanho-fonte: 18px;
+    altura-linha: 1.6;
+}
+
+titulo1 {
+    cor: #0e3a5f;
+}

--- a/fontes/interface-linha-comando/exemplos/pitugues/mvc/rotas/inicial.pitu
+++ b/fontes/interface-linha-comando/exemplos/pitugues/mvc/rotas/inicial.pitu
@@ -1,0 +1,4 @@
+funcao rota_inicial(requisicao, resposta):
+    resposta.lmht({"nome": "mundo"})
+
+liquido.rotaGet(rota_inicial)

--- a/fontes/interface-linha-comando/exemplos/pitugues/mvc/visoes/inicial.lmht
+++ b/fontes/interface-linha-comando/exemplos/pitugues/mvc/visoes/inicial.lmht
@@ -1,0 +1,16 @@
+<lmht>
+    <cabeça>
+        <meta nome="viewport" conteudo="width=device-width, initial-scale=1.0" />
+        <recurso tipo="stylesheet" destino="/css/principal.css" />
+        <titulo>Bem-vindo ao Liquido</titulo>
+    </cabeça>
+    <corpo>
+        <titulo1>Olá, {{nome}}!</titulo1>
+        <p>Sua aplicação MVC em Liquido está no ar.</p>
+        <p>Para começar:</p>
+        <p>— A rota desta página fica em rotas/inicial.pitu;</p>
+        <p>— Esta visão fica em visoes/inicial.lmht;</p>
+        <p>— O estilo fica em estilos/principal.foles, transpilado automaticamente para publico/css/principal.css.</p>
+        <p>Qualquer alteração nesses diretórios recarrega a aplicação automaticamente. Boa jornada!</p>
+    </corpo>
+</lmht>

--- a/testes/interface-linha-comando/novo.test.ts
+++ b/testes/interface-linha-comando/novo.test.ts
@@ -1,0 +1,82 @@
+import * as sistemaArquivos from 'fs';
+import * as so from 'os';
+import caminho from 'path';
+
+import { copiarArquivosDeExemploParaNovoProjeto } from '../../fontes/interface-linha-comando/novo';
+
+/**
+ * Testes de regressão para o achado A4 (issue #103):
+ * o scaffold MVC não pode gerar um projeto sem código executável.
+ * Todo template deve entregar, no mínimo, uma rota inicial, uma visão
+ * inicial e um estilo inicial, para que `npx liquido` responda com uma
+ * página de boas-vindas no primeiro boot.
+ */
+describe('Comando novo - cópia de arquivos de exemplo', () => {
+    let diretorioTemporario: string;
+
+    beforeEach(() => {
+        diretorioTemporario = sistemaArquivos.mkdtempSync(
+            caminho.join(so.tmpdir(), 'liquido-novo-')
+        );
+    });
+
+    afterEach(() => {
+        sistemaArquivos.rmSync(diretorioTemporario, { recursive: true, force: true });
+    });
+
+    const casosMvc: [string, string][] = [
+        ['delegua', 'inicial.delegua'],
+        ['pitugues', 'inicial.pitu']
+    ];
+
+    it.each(casosMvc)(
+        'projeto MVC em %s deve conter rota, visão e estilo iniciais',
+        async (linguagem: string, arquivoRota: string) => {
+            await copiarArquivosDeExemploParaNovoProjeto(
+                'meu-projeto',
+                'mvc',
+                linguagem,
+                diretorioTemporario
+            );
+
+            const arquivosEsperados = [
+                caminho.join(diretorioTemporario, 'rotas', arquivoRota),
+                caminho.join(diretorioTemporario, 'visoes', 'inicial.lmht'),
+                caminho.join(diretorioTemporario, 'estilos', 'principal.foles'),
+                caminho.join(diretorioTemporario, 'configuracao.delprops')
+            ];
+
+            for (const arquivoEsperado of arquivosEsperados) {
+                expect(sistemaArquivos.existsSync(arquivoEsperado)).toBe(true);
+                const conteudo = sistemaArquivos.readFileSync(arquivoEsperado, 'utf-8');
+                expect(conteudo.trim().length).toBeGreaterThan(0);
+            }
+
+            // A rota inicial deve renderizar a visão (padrão MVC), e não texto puro.
+            const conteudoRota = sistemaArquivos.readFileSync(
+                caminho.join(diretorioTemporario, 'rotas', arquivoRota),
+                'utf-8'
+            );
+            expect(conteudoRota).toContain('liquido.rotaGet');
+            expect(conteudoRota).toContain('resposta.lmht');
+        }
+    );
+
+    it.each([['delegua', 'inicial.delegua'], ['pitugues', 'inicial.pitu']])(
+        'projeto API REST em %s deve continuar contendo rota inicial',
+        async (linguagem: string, arquivoRota: string) => {
+            await copiarArquivosDeExemploParaNovoProjeto(
+                'meu-projeto',
+                'api-rest',
+                linguagem,
+                diretorioTemporario
+            );
+
+            expect(
+                sistemaArquivos.existsSync(
+                    caminho.join(diretorioTemporario, 'rotas', arquivoRota)
+                )
+            ).toBe(true);
+        }
+    );
+});


### PR DESCRIPTION
# Corrige scaffold MVC vazio: adiciona rota, visão e estilo iniciais

Fixes #103

## Problema

O template MVC (Delégua e Pituguês) do comando `liquido novo` criava apenas arquivos `LEIAME.md` nos diretórios — nenhuma rota, visão ou estilo de exemplo. Rodar o projeto recém-gerado resultava em 404 (em inglês) na raiz. O template API REST, em contraste, já trazia `rotas/inicial` funcionando.

## Solução

Mudança **puramente aditiva** nos templates de `fontes/interface-linha-comando/exemplos/{delegua,pitugues}/mvc/`. Nenhuma alteração de código foi necessária: `copiarArquivosDeExemploParaNovoProjeto` já copia qualquer arquivo `{delegua,pitu,delprops,foles,lmht,md}`, e o script `empacotar` já inclui `exemplos/**/*` no pacote publicado.

Arquivos adicionados a cada template MVC:

| Arquivo | Papel |
|---|---|
| `rotas/inicial.delegua` / `rotas/inicial.pitu` | Rota `GET /` que renderiza a visão via `resposta.lmht({"nome": "mundo"})` |
| `visoes/inicial.lmht` | Página de boas-vindas em português com meta viewport, CSS referenciado via `<recurso tipo="stylesheet" destino="/css/principal.css"/>` e orientações de próximos passos |
| `estilos/principal.foles` | Estilo inicial (cor-fundo, cor, margem, tamanho-fonte, altura-linha, titulo1), transpilado automaticamente para `publico/css/principal.css` |

Com isso, o primeiro boot de um projeto MVC entrega o "momento uau" que `rails new`, `nest new` e `create-next-app` entregam: uma página funcionando.

## Nota de compatibilidade descoberta durante a validação

Em **Pituguês**, encadear `.status(200)` após `resposta.lmht()` falha em runtime com `LIQ99999: Só pode chamar função ou classe` (em Delégua o encadeamento funciona). Por isso as rotas dos templates **não usam encadeamento** — 200 já é o status padrão. Pode valer uma issue separada para o encadeamento de métodos de `Resposta` no interpretador Pituguês.

## Testes

Novo `testes/interface-linha-comando/novo.test.ts` com 4 casos de regressão:

- Projeto MVC em Delégua e em Pituguês deve conter `rotas/inicial.*`, `visoes/inicial.lmht`, `estilos/principal.foles` e `configuracao.delprops`, todos não-vazios, com a rota contendo `liquido.rotaGet` e `resposta.lmht`;
- Projeto API REST em ambas as linguagens deve continuar contendo `rotas/inicial.*`.

```
PASS liquido testes/interface-linha-comando/novo.test.ts
  ✓ projeto MVC em delegua deve conter rota, visão e estilo iniciais
  ✓ projeto MVC em pitugues deve conter rota, visão e estilo iniciais
  ✓ projeto API REST em delegua deve continuar contendo rota inicial
  ✓ projeto API REST em pitugues deve continuar contendo rota inicial

Test Suites: 5 passed, 5 total (suíte interface-linha-comando + liquido.test.ts)
Tests:       57 passed, 57 total
```

## Validação manual (runtime real)

Templates copiados para projetos limpos e executados com `liquido@1.4.0` publicado no npm, nas duas linguagens:

```
GET /                      → 200, página de boas-vindas renderizada (LMHT → HTML)
GET /css/principal.css     → 200, FolEs transpilado (corpo→body, cor-fundo→background-color)
```

## Checklist

- [x] Mudança aditiva, sem alteração de comportamento do código existente
- [x] Teste de regressão incluído e passando
- [x] Validado em runtime com o pacote npm publicado (Delégua e Pituguês)
- [x] Sem novas dependências
- [x] Conteúdo dos templates 100% em português
