### PR TITLE
Corrige tag LMHT e nome de arquivo de configuração

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Cada arquivo só pode ter uma chamada por método HTTP de rota. Por exemplo, um 
 - `liquido.rotaUnlock()`
 - `liquido.rotaPropfind()`
 
-Algumas rotas ainda não são suportadas porque o Express.js 4 não as implementou, mas estão marcadas para implementações futuras (Express.js 5, que ainda é _beta_). São elas:
+Algumas rotas ainda não são suportadas porque o Express.js 4 não as implementou, mas estão marcadas para implementações futuras (Express.js ^5.2.1 __estável__). São elas:
 
 - `liquido.rotaLink()`
 - `liquido.rotaUnlink()`

--- a/fontes/infraestrutura/provedores/README.md
+++ b/fontes/infraestrutura/provedores/README.md
@@ -1,3 +1,3 @@
 # Provedores
 
-São classes que resolvem uma determinada configuração do ambiente (normalmente provida em `configuracao.delegua`). Por exemplo, se a configuração irá usar LinConEs para acesso a bancos de dados, a classe `ProvedorLincones` fará toda a configuração da instância de LinConEs com a tecnologia selecionada na configuração. O retorno é um objeto que Delégua consegue trabalhar.
+São classes que resolvem uma determinada configuração do ambiente (normalmente provida em `configuracao.delprops`). Por exemplo, se a configuração irá usar LinConEs para acesso a bancos de dados, a classe `ProvedorLincones` fará toda a configuração da instância de LinConEs com a tecnologia selecionada na configuração. O retorno é um objeto que Delégua consegue trabalhar.

--- a/visoes/inicial.lmht
+++ b/visoes/inicial.lmht
@@ -13,8 +13,8 @@
     </cabeça>
     <corpo>
         <artigo>
-            <titulo1>Meu primeiro artigo</titulo>
-            <p>Este é meu primeiro artigo.</p>
+            <titulo1> Meu primeiro artigo</titulo1>
+            <p> Este é meu primeiro artigo.</p>
         </artigo>
     </corpo>
 </lmht>


### PR DESCRIPTION
# Descrição
Esta PR tem como objetivo atualizar a documentação do projeto e corrigir tags incorretas no arquivo `inicial.lmht`. 
## Alterações
- Atualização do nome do arquivo `configuracao.delegua` para `configuracao.delprops` no arquivo `README.md`,  `fontes\infraestrutura\provedores\README.md` e no artigo `Arquitetura MVC no Liquido`.
- Correção da tag de fechamento de `<titulo1>` no arquivo `inicial.lmht`, garantindo que o conteúdo do artigo seja exibido corretamente.
## Ganhos
Com essa alteração, a documentação do projeto estará mais precisa e consistente, facilitando a compreensão para novos desenvolvedores e usuários. Além disso, a correção da tag no arquivo `inicial.lmht` garante que o conteúdo do artigo seja exibido corretamente, facilitando a leitura e compreensão do mesmo.
fix #118
