### PR TITLE
Comando documentar passa a reportar resultado explícito e gerar opena…

### DIFF
--- a/fontes/infraestrutura/auto-documentacao/auto-documentador.ts
+++ b/fontes/infraestrutura/auto-documentacao/auto-documentador.ts
@@ -184,7 +184,6 @@ export class AutoDocumentador implements AutoDocumentadorInterface {
         caminhoControlador: string,
         declaracoes: Declaracao[]
     ): [string, { [key in MetodoHttpOpenApi]?: RotaOpenApi }] {
-        this.erros = [];
         const descritivoControlador: { [key in MetodoHttpOpenApi]?: RotaOpenApi } = {};
         const rotaRelativa = caminhoControlador
             .replace(this.diretorioRotas, '')
@@ -228,6 +227,7 @@ export class AutoDocumentador implements AutoDocumentadorInterface {
     }
 
     async documentar() {
+        this.erros = [];
         const rotasEControladores = await this.encontrarControladores();
         const documento: DocumentoOpenApi = {
             openapi: '3.0.0',

--- a/fontes/interface-linha-comando/documentar/index.ts
+++ b/fontes/interface-linha-comando/documentar/index.ts
@@ -1,7 +1,42 @@
-import { AutoDocumentador } from "../../infraestrutura/auto-documentacao/auto-documentador";
+import * as sistemaArquivos from 'fs';
+import caminho from 'path';
+import { yellow } from 'chalk';
 
-export async function documentar() {
-    // TODO: Terminar após finalizar auto-documentador.
+import { AutoDocumentador } from '../../infraestrutura/auto-documentacao/auto-documentador';
+
+/**
+ * Comando `liquido documentar`.
+ *
+ * Lê as rotas do projeto e gera um arquivo `openapi.json` na raiz do
+ * projeto com a especificação OpenAPI correspondente.
+ *
+ * O comando sempre termina com um resultado explícito no console:
+ * - O caminho do arquivo gerado e o número de rotas documentadas; ou
+ * - O motivo de nenhum arquivo ter sido gerado (nenhuma rota encontrada
+ *   no diretório esperado), além de avisos de análise, se houver.
+ *
+ * @param caminhoSaida Caminho do arquivo de saída. Quando não informado,
+ *                     usa `openapi.json` na raiz do projeto (diretório atual).
+ */
+export async function documentar(caminhoSaida?: string): Promise<void> {
     const autoDocumentador = new AutoDocumentador();
-    await autoDocumentador.documentar();
+    const documento = await autoDocumentador.documentar();
+
+    for (const erro of autoDocumentador.erros) {
+        console.log(yellow(`Aviso: ${erro.message}`));
+    }
+
+    const rotasDocumentadas = Object.keys(documento.paths || {});
+    if (rotasDocumentadas.length === 0) {
+        console.log(`Nenhum arquivo de rota (.delegua) foi encontrado em: ${autoDocumentador.diretorioRotas}`);
+        console.log('Nenhum arquivo de documentação foi gerado.');
+        return;
+    }
+
+    const caminhoArquivoSaida = caminhoSaida || caminho.join(process.cwd(), 'openapi.json');
+    sistemaArquivos.writeFileSync(caminhoArquivoSaida, JSON.stringify(documento, undefined, 4) + '\n');
+
+    console.log(
+        `Documentação OpenAPI gerada com ${rotasDocumentadas.length} rota(s) em: ${caminhoArquivoSaida}`
+    );
 }

--- a/testes/interface-linha-comando/documentar.test.ts
+++ b/testes/interface-linha-comando/documentar.test.ts
@@ -1,0 +1,91 @@
+import * as sistemaArquivos from 'fs';
+import * as so from 'os';
+import caminho from 'path';
+
+import { documentar } from '../../fontes/interface-linha-comando/documentar';
+
+/**
+ * Testes de regressão para o achado M7 (issue #114):
+ * `liquido documentar` não pode terminar em silêncio. Todo desfecho
+ * deve ser reportado explicitamente no console — o arquivo gerado e
+ * seu caminho, ou o motivo de nenhum arquivo ter sido gerado.
+ */
+describe('Comando documentar', () => {
+    let diretorioTemporario: string;
+    let espiaoConsole: jest.SpyInstance;
+    let espiaoCwd: jest.SpyInstance;
+
+    const saidaConsole = (): string =>
+        espiaoConsole.mock.calls.map((chamada) => String(chamada[0])).join('\n');
+
+    beforeEach(() => {
+        diretorioTemporario = sistemaArquivos.mkdtempSync(
+            caminho.join(so.tmpdir(), 'liquido-documentar-')
+        );
+        espiaoConsole = jest.spyOn(console, 'log').mockImplementation(() => {});
+        espiaoCwd = jest.spyOn(process, 'cwd').mockReturnValue(diretorioTemporario);
+    });
+
+    afterEach(() => {
+        espiaoConsole.mockRestore();
+        espiaoCwd.mockRestore();
+        sistemaArquivos.rmSync(diretorioTemporario, { recursive: true, force: true });
+    });
+
+    it('deve reportar explicitamente quando nenhuma rota é encontrada e não gerar arquivo', async () => {
+        await documentar();
+
+        const saida = saidaConsole();
+        expect(saida).toContain('Nenhum arquivo de rota');
+        expect(saida).toContain(caminho.join(diretorioTemporario, 'rotas/rest').replace(/\\/gi, '/'));
+        expect(saida).toContain('Nenhum arquivo de documentação foi gerado.');
+
+        expect(
+            sistemaArquivos.existsSync(caminho.join(diretorioTemporario, 'openapi.json'))
+        ).toBe(false);
+    });
+
+    it('deve gerar openapi.json e reportar caminho e número de rotas', async () => {
+        const diretorioRota = caminho.join(diretorioTemporario, 'rotas', 'rest', 'artigos');
+        sistemaArquivos.mkdirSync(diretorioRota, { recursive: true });
+        sistemaArquivos.writeFileSync(
+            caminho.join(diretorioRota, 'inicial.delegua'),
+            [
+                'liquido.rotaGet(funcao(requisicao, resposta) {',
+                '    resposta.json([])',
+                '})'
+            ].join('\n')
+        );
+
+        await documentar();
+
+        const caminhoSaida = caminho.join(diretorioTemporario, 'openapi.json');
+        expect(sistemaArquivos.existsSync(caminhoSaida)).toBe(true);
+
+        const documento = JSON.parse(sistemaArquivos.readFileSync(caminhoSaida, 'utf-8'));
+        expect(documento.openapi).toBe('3.0.0');
+        expect(Object.keys(documento.paths)).toHaveLength(1);
+        expect(documento.paths['/artigos/']).toBeDefined();
+
+        const saida = saidaConsole();
+        expect(saida).toContain('Documentação OpenAPI gerada com 1 rota(s) em:');
+        expect(saida).toContain(caminhoSaida);
+        // Erros de análise acumulados não podem mais ser engolidos em silêncio.
+        expect(saida).toContain('Aviso:');
+    });
+
+    it('deve gravar no caminho de saída informado quando fornecido', async () => {
+        const diretorioRota = caminho.join(diretorioTemporario, 'rotas', 'rest');
+        sistemaArquivos.mkdirSync(diretorioRota, { recursive: true });
+        sistemaArquivos.writeFileSync(
+            caminho.join(diretorioRota, 'inicial.delegua'),
+            'liquido.rotaGet(funcao(requisicao, resposta) {\n    resposta.json([])\n})'
+        );
+
+        const caminhoPersonalizado = caminho.join(diretorioTemporario, 'docs.json');
+        await documentar(caminhoPersonalizado);
+
+        expect(sistemaArquivos.existsSync(caminhoPersonalizado)).toBe(true);
+        expect(saidaConsole()).toContain(caminhoPersonalizado);
+    });
+});


### PR DESCRIPTION
# Comando `documentar` passa a reportar resultado explícito e gerar `openapi.json`

Fixes #114

## Problema

`npx liquido documentar` imprimia o banner e terminava em silêncio absoluto. Na prática, o comando não fazia nada observável: o documento OpenAPI era montado em memória pelo `AutoDocumentador` e **descartado** pela camada de CLI (havia até um `// TODO: Terminar após finalizar auto-documentador.` no wrapper) — nenhum arquivo gravado, nenhuma mensagem de resultado, nenhum erro.

## Solução

O comando agora sempre termina com um desfecho explícito, cobrindo a sugestão da issue ("reportar ação realizada — arquivo gerado, caminho — ou motivo de não ter feito nada"):

**Quando há rotas** — grava a especificação em `openapi.json` na raiz do projeto e reporta:

```
Documentação OpenAPI gerada com 3 rota(s) em: /caminho/do/projeto/openapi.json
```

**Quando não há rotas** — informa exatamente onde procurou e por que nada foi gerado:

```
Nenhum arquivo de rota (.delegua) foi encontrado em: /caminho/do/projeto/rotas/rest
Nenhum arquivo de documentação foi gerado.
```

**Avisos de análise** — erros acumulados pelo `AutoDocumentador` agora são exibidos com prefixo `Aviso:` (em amarelo, via chalk já usado no projeto), em vez de morrerem silenciosamente no array interno.

A função `documentar()` também aceita um caminho de saída opcional, o que facilita testes e usos programáticos.

## Correção acessória necessária (`AutoDocumentador`)

O reset `this.erros = []` ficava dentro de `lerControlador`, executado **por arquivo** — apagando tanto os erros de análise registrados por `obterEstruturasDeAltoNivelDeControlador` (que roda *antes* dele) quanto os erros de arquivos anteriores. Na prática, os avisos nunca sobreviviam para serem reportados. O reset foi movido para o início de `documentar()`, acumulando todos os avisos de uma execução. Os testes existentes do `AutoDocumentador` seguem passando sem alteração (cada teste instancia um objeto novo).

## Testes

Novo `testes/interface-linha-comando/documentar.test.ts` com 3 casos:

1. Sem rotas → mensagens explícitas (diretório varrido + "nenhum arquivo gerado") e **nenhum** `openapi.json` criado;
2. Com rota → `openapi.json` válido gravado (`openapi: 3.0.0`, path presente), contagem e caminho reportados, e avisos de análise visíveis;
3. Caminho de saída customizado respeitado e reportado.

```
Test Suites: 15 passed, 15 total
Tests:       160 passed, 160 total
(suítes interface-linha-comando + infraestrutura + liquido.test.ts)
```

## Observação de escopo (relaciona-se ao achado M3)

Os métodos HTTP de cada rota ainda saem **vazios** na especificação: o avaliador sintático não conhece o global `liquido` e registra `Variável não definida: 'liquido'` para todo arquivo de rota — inclusive para o fixture do próprio repositório (`testes/exemplos/rotas/inicial.delegua`; o teste existente só verifica `Array.isArray`, então passa mesmo com a análise falhando). Essa é a causa-raiz do achado M3 (*OpenAPI gerado vazio*) e merece correção própria — provavelmente pré-registrando `liquido` no escopo do avaliador. Com este PR, o aviso correspondente ao menos se torna **visível** ao usuário, em vez de ser engolido.

## Checklist

- [x] Comando nunca mais termina em silêncio (os três desfechos são reportados)
- [x] Arquivo gerado com caminho explícito, conforme sugestão da issue
- [x] Bug de acúmulo de erros corrigido com justificativa
- [x] 3 testes de regressão novos; 160 testes passando nas suítes relacionadas
- [x] Sem novas dependências; mensagens 100% em português
