### PR TITLE
Erros de execução em português, com código específico, arquivo e linh…

### DIFF
--- a/fontes/erros.ts
+++ b/fontes/erros.ts
@@ -1,10 +1,57 @@
-export const listaDeErros = [
+/**
+ * Mapeamento de erros de execução para códigos de Liquido.
+ *
+ * `palavraChave` é comparada (em minúsculas) com a mensagem original do erro.
+ * `mensagem`, quando presente, é a explicação amigável em português exibida
+ * ao desenvolvedor no console e na resposta HTTP de erro; a mensagem original
+ * é preservada como detalhe técnico.
+ *
+ * `LIQ99999` continua sendo o código de contingência para erros ainda não
+ * mapeados. Ao encontrar um LIQ99999 recorrente, o caminho é adicionar aqui
+ * uma nova entrada com código próprio e mensagem em português.
+ */
+export interface ErroMapeadoInterface {
+    codigo: string;
+    palavraChave: string;
+    mensagem?: string;
+}
+
+export const listaDeErros: ErroMapeadoInterface[] = [
     { codigo: 'LIQ00001', palavraChave: 'não encontrado' },
     { codigo: 'LIQ00002', palavraChave: 'não foi definida' },
     { codigo: 'LIQ00003', palavraChave: 'inesperado' },
+    // Erros vindos do motor JavaScript, normalmente por valores nulos ou
+    // indefinidos chegando onde não deviam. A mensagem original (em inglês)
+    // é traduzida para orientar quem está começando.
+    {
+        codigo: 'LIQ20001',
+        palavraChave: 'cannot read propert',
+        mensagem: 'Tentativa de acessar uma propriedade de um valor nulo ou indefinido.'
+    },
+    {
+        codigo: 'LIQ20002',
+        palavraChave: 'is not a function',
+        mensagem: 'Tentativa de chamar como função algo que não é uma função.'
+    },
+    {
+        codigo: 'LIQ20003',
+        palavraChave: 'is not defined',
+        mensagem: 'Uso de um nome que não foi definido.'
+    },
+    // Erros do interpretador Delégua/Pituguês que já chegam em português,
+    // mas merecem código próprio para diagnóstico.
+    { codigo: 'LIQ20004', palavraChave: 'só pode chamar função ou classe' },
     // Erro genérico de LinConEs: o driver de banco de dados (SQLite, MySQL, PostgreSQL etc.)
     // rejeitou o comando (violação de restrição, sintaxe SQL inválida, etc.) e a mensagem
     // de erro nativa do driver chegou sem tratamento específico até aqui.
-    { codigo: 'LIQ10000', palavraChave: 'sqlite_' },
-    { codigo: 'LIQ10000', palavraChave: 'constraint failed' },
+    {
+        codigo: 'LIQ10000',
+        palavraChave: 'sqlite_',
+        mensagem: 'O banco de dados rejeitou o comando executado.'
+    },
+    {
+        codigo: 'LIQ10000',
+        palavraChave: 'constraint failed',
+        mensagem: 'O banco de dados rejeitou o comando por violação de restrição.'
+    }
 ];

--- a/fontes/interfaces/interface-liquido.ts
+++ b/fontes/interfaces/interface-liquido.ts
@@ -24,5 +24,5 @@ export interface LiquidoInterface {
     prepararRequisicao(requisicao: any, nomeFuncao: string, funcaoConstruto: FuncaoConstruto): void;
 
     chamarInterpretador(nomeFuncao: string): Promise<RetornoInterpretadorInterface>;
-    adicionarRota(metodoRoteador: string, caminhoRota: string, argumentos: ConstrutoInterface[]): void;
+    adicionarRota(metodoRoteador: string, caminhoRota: string, argumentos: ConstrutoInterface[], arquivoFonte?: string): void;
 }

--- a/fontes/liquido.ts
+++ b/fontes/liquido.ts
@@ -560,7 +560,8 @@ export class Liquido implements LiquidoInterface {
                                 arquivo,
                                 linguagemSelecionada
                             ),
-                            argumentosResolvidos
+                            argumentosResolvidos,
+                            arquivo
                         );
                     }
                 }
@@ -636,29 +637,37 @@ export class Liquido implements LiquidoInterface {
         }
     }
 
-    private classificarErro(erro: ErroInterpretadorInterface): string {
+    private classificarErro(erro: ErroInterpretadorInterface): { codigo: string; mensagemAmigavel?: string } {
         const textoErro = (erro.mensagem || erro.erroInterno?.message || '').toLowerCase();
 
         for (const item of listaDeErros) {
             if (textoErro.includes(item.palavraChave)) {
-                return item.codigo;
+                return { codigo: item.codigo, mensagemAmigavel: item.mensagem };
             }
         }
 
-        return 'LIQ99999';
+        return { codigo: 'LIQ99999' };
     }
 
     private logicaComumErrosInterpretacao(
-        retornoInterpretador: RetornoInterpretadorInterface
+        retornoInterpretador: RetornoInterpretadorInterface,
+        arquivoFonte?: string
     ): {
         corpoRetorno?: any;
         statusHttp?: number;
         redirecionamento?: string;
+        tipoConteudo?: string;
     } {
         const listaErros: string[] = [];
 
         for (const erro of retornoInterpretador.erros) {
-            const tipoErro = this.classificarErro(erro);
+            const { codigo, mensagemAmigavel } = this.classificarErro(erro);
+            const localizacao = [
+                arquivoFonte ? `Arquivo: ${arquivoFonte}` : undefined,
+                erro.linha !== undefined && erro.linha > 0 ? `Linha: ${erro.linha}` : undefined
+            ]
+                .filter(Boolean)
+                .join(', ');
 
             if (erro.erroInterno) {
                 const erroInternoTipado: {
@@ -666,18 +675,31 @@ export class Liquido implements LiquidoInterface {
                     pilha: string;
                 } = erro.erroInterno;
 
-                console.error(`[Liquido] ${tipoErro}: ${erroInternoTipado.message}`);
+                const mensagemPrincipal = mensagemAmigavel || erroInternoTipado.message;
+                const detalheTecnico = mensagemAmigavel
+                    ? ` (detalhe técnico: ${erroInternoTipado.message})`
+                    : '';
+
+                console.error(
+                    `[Liquido] ${codigo}${localizacao ? ` [${localizacao}]` : ''}: ${mensagemPrincipal}${detalheTecnico}`
+                );
                 listaErros.push(
                     `
-                    Código: ${tipoErro}\n
-                    Mensagem: ${erroInternoTipado.message}\n
+                    Código: ${codigo}\n
+                    ${localizacao ? `Onde: ${localizacao}\n` : ''}
+                    Mensagem: ${mensagemPrincipal}\n
+                    ${mensagemAmigavel ? `Detalhe técnico: ${erroInternoTipado.message}\n` : ''}
                     Pilha: ${erroInternoTipado.pilha}
                     `
                 );
             } else {
-                console.error(`[Liquido] ${tipoErro} - [Linha ${erro.linha}]: ${erro.mensagem}`);
+                const mensagemPrincipal = mensagemAmigavel || erro.mensagem;
+                const detalheTecnico = mensagemAmigavel ? ` (detalhe técnico: ${erro.mensagem})` : '';
+                const prefixoLocalizacao = localizacao ? ` [${localizacao}]` : ` - [Linha ${erro.linha}]`;
+
+                console.error(`[Liquido] ${codigo}${prefixoLocalizacao}: ${mensagemPrincipal}${detalheTecnico}`);
                 listaErros.push(
-                    `${tipoErro} - [Linha ${erro.linha}]: ${erro.mensagem}`
+                    `${codigo}${prefixoLocalizacao}: ${mensagemPrincipal}${detalheTecnico}`
                 );
             }
         }
@@ -793,14 +815,21 @@ export class Liquido implements LiquidoInterface {
             `;
         }
 
-        if (this.centroConfiguracoes.liquido.arquetipo === 'rest') {
+        if (this.centroConfiguracoes.liquido.arquetipo === 'mvc') {
+            return { corpoRetorno: corpoFinal, statusHttp: 500, tipoConteudo: 'HTML' };
+        }
+
+        // Arquétipo 'rest' e qualquer outro valor: resposta estruturada em JSON.
+        // Sem `tipoConteudo`, o corpo (um objeto) era coagido para texto e o
+        // cliente recebia o literal "[object Object]" com text/plain.
+        if (corpoFinal === undefined) {
             corpoFinal = {
                 mensagem: 'Ocorreu um erro interno na aplicação.',
                 detalhes: listaErros
             };
         }
 
-        return { corpoRetorno: corpoFinal, statusHttp: 500 };
+        return { corpoRetorno: corpoFinal, statusHttp: 500, tipoConteudo: 'JSON' };
     }
 
     /**
@@ -900,10 +929,11 @@ export class Liquido implements LiquidoInterface {
 
     private async logicaComumResultadoInterpretador(
         caminhoRota: string,
-        retornoInterpretador: RetornoInterpretadorInterface
+        retornoInterpretador: RetornoInterpretadorInterface,
+        arquivoFonte?: string
     ): Promise<CorpoResposta> {
         if (retornoInterpretador.erros.length > 0) {
-            return this.logicaComumErrosInterpretacao(retornoInterpretador);
+            return this.logicaComumErrosInterpretacao(retornoInterpretador, arquivoFonte);
         }
 
         let objetoResposta: ObjetoDeleguaClasse | null = null;
@@ -959,17 +989,20 @@ export class Liquido implements LiquidoInterface {
      * @param caminhoRota O caminho da rota.
      * @param funcao A função a ser executada.
      * @param nomeFuncao O nome único para identificar a função no interpretador.
+     * @param arquivoFonte O caminho do arquivo fonte que define a rota, usado
+     *                     para apontar a origem em mensagens de erro.
      * @returns O corpo e status da resposta, se houver.
      */
     private async executarFuncaoRota(
         req: any,
         caminhoRota: string,
         funcao: FuncaoConstruto,
-        nomeFuncao: string
+        nomeFuncao: string,
+        arquivoFonte?: string
     ): Promise<CorpoResposta> {
         await this.prepararRequisicao(req, nomeFuncao, funcao);
         const retornoInterpretador = await this.chamarInterpretador(nomeFuncao);
-        return await this.logicaComumResultadoInterpretador(caminhoRota, retornoInterpretador);
+        return await this.logicaComumResultadoInterpretador(caminhoRota, retornoInterpretador, arquivoFonte);
     }
 
     /**
@@ -979,16 +1012,24 @@ export class Liquido implements LiquidoInterface {
      * @param argumentos Todas as funções em Delégua que devem ser executadas
      *                   para a resolução da rota. O último argumento é o handler final,
      *                   todos os anteriores são middlewares executados em sequência.
+     * @param arquivoFonte O caminho do arquivo fonte que define a rota, usado
+     *                     para apontar a origem em mensagens de erro.
      */
     async adicionarRota(
         metodoRoteador: string,
         caminhoRota: string,
-        argumentos: FuncaoConstruto[]
+        argumentos: FuncaoConstruto[],
+        arquivoFonte?: string
     ): Promise<void> {
         if (argumentos.length === 0) {
             console.error(`Rota ${caminhoRota} não possui nenhuma função definida.`);
             return;
         }
+
+        // Caminho relativo à raiz do projeto, mais legível em mensagens de erro.
+        const arquivoFonteRelativo = arquivoFonte
+            ? caminho.relative(process.cwd(), arquivoFonte)
+            : undefined;
 
         // Separa middlewares (todos menos o último) e handler (último argumento)
         const middlewares = argumentos.slice(0, -1);
@@ -1022,7 +1063,7 @@ export class Liquido implements LiquidoInterface {
                 const middleware = middlewares[i];
                 const nomeMiddleware = `middleware${i}_${metodoRoteador}`;
 
-                corpoEStatus = await this.executarFuncaoRota(req, caminhoRota, middleware, nomeMiddleware);
+                corpoEStatus = await this.executarFuncaoRota(req, caminhoRota, middleware, nomeMiddleware, arquivoFonteRelativo);
 
                 // Se o middleware enviou uma resposta, para a execução
                 if (this.respostaFoiDefinida(corpoEStatus)) {
@@ -1032,7 +1073,7 @@ export class Liquido implements LiquidoInterface {
 
             // Se nenhum middleware enviou resposta, executa o handler final
             if (!this.respostaFoiDefinida(corpoEStatus)) {
-                corpoEStatus = await this.executarFuncaoRota(req, caminhoRota, handler, `handler_${metodoRoteador}`);
+                corpoEStatus = await this.executarFuncaoRota(req, caminhoRota, handler, `handler_${metodoRoteador}`, arquivoFonteRelativo);
             }
 
             // Envia a resposta

--- a/testes/cadeia-middlewares.test.ts
+++ b/testes/cadeia-middlewares.test.ts
@@ -80,7 +80,7 @@ describe('Cadeia de middlewares — adicionarRota', () => {
 
         expect(executarFuncaoRotaSpy).toHaveBeenCalledTimes(1);
         expect(executarFuncaoRotaSpy).toHaveBeenCalledWith(
-            mockReq, '/teste', handler, 'handler_rotaGet'
+            mockReq, '/teste', handler, 'handler_rotaGet', undefined
         );
     });
 

--- a/testes/tratamento-erros.test.ts
+++ b/testes/tratamento-erros.test.ts
@@ -1,0 +1,125 @@
+import { Liquido } from '../fontes/liquido';
+
+/**
+ * Testes de regressão para o achado A1 (issue #100):
+ * erros de runtime não podem chegar ao cliente como "[object Object]"
+ * em text/plain, nem ao console como mensagens cruas em inglês com o
+ * código genérico LIQ99999 sem localização.
+ */
+describe('Tratamento de erros de interpretação', () => {
+    let liquido: Liquido;
+
+    beforeEach(() => {
+        liquido = new Liquido(process.cwd());
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const erroInternoDeRuntime = () => ({
+        erros: [
+            {
+                erroInterno: {
+                    message: "Cannot read properties of undefined (reading 'name')",
+                    pilha: 'pilha simulada'
+                }
+            }
+        ]
+    });
+
+    describe('Arquétipo REST', () => {
+        beforeEach(() => {
+            (liquido as any).centroConfiguracoes = { liquido: { arquetipo: 'rest' } };
+        });
+
+        it('deve responder JSON estruturado, nunca "[object Object]"', () => {
+            const resultado = (liquido as any).logicaComumErrosInterpretacao(erroInternoDeRuntime());
+
+            expect(resultado.statusHttp).toBe(500);
+            expect(resultado.tipoConteudo).toBe('JSON');
+            expect(typeof resultado.corpoRetorno).toBe('object');
+            expect(resultado.corpoRetorno.mensagem).toBe('Ocorreu um erro interno na aplicação.');
+            expect(String(resultado.corpoRetorno)).not.toBe(resultado.corpoRetorno);
+        });
+
+        it('deve traduzir erros conhecidos do motor JavaScript para português com código próprio', () => {
+            const resultado = (liquido as any).logicaComumErrosInterpretacao(erroInternoDeRuntime());
+            const detalhes = resultado.corpoRetorno.detalhes.join('\n');
+
+            expect(detalhes).toContain('LIQ20001');
+            expect(detalhes).not.toContain('LIQ99999');
+            expect(detalhes).toContain('Tentativa de acessar uma propriedade de um valor nulo ou indefinido.');
+            // A mensagem original é preservada como detalhe técnico.
+            expect(detalhes).toContain("Cannot read properties of undefined (reading 'name')");
+        });
+
+        it('deve apontar arquivo e linha do código do usuário quando disponíveis', () => {
+            const erroComLocalizacao = {
+                erros: [
+                    {
+                        linha: 7,
+                        erroInterno: {
+                            message: "Cannot read properties of undefined (reading 'name')",
+                            pilha: 'pilha simulada'
+                        }
+                    }
+                ]
+            };
+
+            const resultado = (liquido as any).logicaComumErrosInterpretacao(
+                erroComLocalizacao,
+                'rotas/usuarios/[id].pitu'
+            );
+            const detalhes = resultado.corpoRetorno.detalhes.join('\n');
+
+            expect(detalhes).toContain('Arquivo: rotas/usuarios/[id].pitu');
+            expect(detalhes).toContain('Linha: 7');
+        });
+
+        it('deve manter LIQ99999 apenas para erros ainda não mapeados', () => {
+            const erroDesconhecido = {
+                erros: [
+                    {
+                        erroInterno: {
+                            message: 'some very unusual internal failure',
+                            pilha: 'pilha simulada'
+                        }
+                    }
+                ]
+            };
+
+            const resultado = (liquido as any).logicaComumErrosInterpretacao(erroDesconhecido);
+            expect(resultado.corpoRetorno.detalhes.join('\n')).toContain('LIQ99999');
+        });
+    });
+
+    describe('Arquétipo MVC', () => {
+        beforeEach(() => {
+            (liquido as any).centroConfiguracoes = { liquido: { arquetipo: 'mvc' } };
+        });
+
+        it('deve responder a página de erro com tipoConteudo HTML, nunca text/plain', () => {
+            const resultado = (liquido as any).logicaComumErrosInterpretacao(erroInternoDeRuntime());
+
+            expect(resultado.statusHttp).toBe(500);
+            expect(resultado.tipoConteudo).toBe('HTML');
+            expect(resultado.corpoRetorno).toContain('Erro de Execução - Líquido');
+            expect(resultado.corpoRetorno).toContain('LIQ20001');
+        });
+    });
+
+    describe('Arquétipo desconhecido ou ausente', () => {
+        it('deve devolver JSON estruturado em vez de corpo indefinido', () => {
+            (liquido as any).centroConfiguracoes = { liquido: { arquetipo: 'api-rest' } };
+
+            const resultado = (liquido as any).logicaComumErrosInterpretacao(erroInternoDeRuntime());
+
+            expect(resultado.statusHttp).toBe(500);
+            expect(resultado.tipoConteudo).toBe('JSON');
+            expect(resultado.corpoRetorno).toBeDefined();
+            expect(resultado.corpoRetorno.mensagem).toBe('Ocorreu um erro interno na aplicação.');
+        });
+    });
+});


### PR DESCRIPTION
# Erros de execução em português, com código específico, arquivo e linha

Fixes #100

## Problema

Falhas de runtime chegavam ao console como `LIQ99999: Cannot read properties of undefined (reading 'name')` e ao cliente HTTP como o corpo literal `[object Object]` com `Content-Type: text/plain`. Sem português, sem código discriminante, sem arquivo/linha do código do usuário.

## Diagnóstico

Eram três problemas independentes se somando:

1. **Entrega** — `logicaComumErrosInterpretacao` já montava um objeto JSON (REST) e até uma **página HTML de erro rica** (MVC), mas não definia `tipoConteudo` no retorno. Na expedição da resposta, sem `tipoConteudo`, o corpo caía no ramo `text/plain` e era coagido com `String(corpo)` — objetos viravam `[object Object]` e a página HTML do MVC (que já existia!) era exibida como texto cru.
2. **Classificação** — `classificarErro` mapeava por palavra-chave para um código, mas sem tradução: a mensagem crua do motor JavaScript (em inglês) era repassada, e quase tudo caía no genérico `LIQ99999`.
3. **Localização** — o caminho do arquivo fonte da rota existia no momento do registro (`adicionarRota`), mas nunca chegava à montagem das mensagens de erro; a `linha` do interpretador só aparecia em um dos dois ramos.

## Solução

**1. Entrega correta por arquétipo** (`fontes/liquido.ts`):
- `mvc` → `tipoConteudo: 'HTML'` — a página de erro rica finalmente renderiza no navegador;
- `rest` → `tipoConteudo: 'JSON'` — resposta estruturada `{ mensagem, detalhes }` com `application/json`;
- arquétipo desconhecido/ausente → fallback em JSON estruturado (antes: corpo `undefined`).

**2. Taxonomia com mensagens em português** (`fontes/erros.ts`): `listaDeErros` aceita `mensagem` amigável por entrada e ganha códigos para os erros de runtime mais comuns:

| Código | Gatilho | Mensagem em português |
|---|---|---|
| LIQ20001 | `cannot read propert` | Tentativa de acessar uma propriedade de um valor nulo ou indefinido. |
| LIQ20002 | `is not a function` | Tentativa de chamar como função algo que não é uma função. |
| LIQ20003 | `is not defined` | Uso de um nome que não foi definido. |
| LIQ20004 | `só pode chamar função ou classe` | (já em português; ganha código próprio) |
| LIQ10000 | erros de driver de banco | Mensagens amigáveis para rejeição/violação de restrição |

A mensagem original é sempre preservada como **detalhe técnico**. `LIQ99999` fica reservado ao que ainda não foi mapeado — e o caminho para eliminá-lo é adicionar entradas nesta lista.

**3. Arquivo e linha do código do usuário**: o arquivo fonte da rota é encanado do registro (`adicionarRota`, novo parâmetro **opcional** — sem quebra de compatibilidade; interface atualizada) até as mensagens, exibido relativo à raiz do projeto, junto da linha do interpretador quando disponível.

## Antes e depois (mesmo cenário real)

Console:

```
ANTES:  [Liquido] LIQ99999: Cannot read properties of undefined (reading 'name')

DEPOIS: [Liquido] LIQ20001 [Arquivo: rotas/usuarios/[id].pitu, Linha: 2]:
        Tentativa de acessar uma propriedade de um valor nulo ou indefinido.
        (detalhe técnico: Cannot read properties of undefined (reading 'name'))
```

Cliente HTTP:

```
ANTES:  HTTP 500 | text/plain | [object Object]

DEPOIS (rest): HTTP 500 | application/json
{ "mensagem": "Ocorreu um erro interno na aplicação.",
  "detalhes": ["Código: LIQ20001 / Onde: Arquivo: rotas/clientes/[id].delegua, Linha: 2 / Mensagem: ... / Detalhe técnico: ... / Pilha: ..."] }

DEPOIS (mvc): HTTP 500 | text/html | página "Erro de Execução - Líquido" renderizada
```

## Validação de ponta a ponta

Código compilado (`tsc`) e sobreposto ao pacote `liquido@1.4.0` instalado, reproduzindo o erro real de parâmetro de rota (`requisicao.parametros.id`) em projetos Delégua (rest) e Pituguês (mvc) — os quatro resultados acima confirmados por requisição HTTP real.

## Testes

- Novo `testes/tratamento-erros.test.ts` com 7 casos: JSON estruturado no REST (nunca `[object Object]`), tradução com código próprio e detalhe técnico preservado, arquivo + linha na saída, `LIQ99999` apenas para não mapeados, `tipoConteudo: 'HTML'` no MVC, e fallback JSON para arquétipo desconhecido.
- `testes/cadeia-middlewares.test.ts`: uma expectativa atualizada para a nova assinatura de `executarFuncaoRota` (5º parâmetro opcional).
- Teste pré-existente da tela de erro MVC continua passando sem alteração.

```
Suíte unitária completa: 233 testes passando (23 suítes)
npx tsc --noEmit: sem erros
```

## Fora do escopo (deliberadamente)

- Trecho de código-fonte na página de erro (estilo Next.js) — exigiria mapear `hashArquivo` → conteúdo via Importador; boa evolução futura sobre a base deste PR.
- Página 404 em inglês para rotas inexistentes (achado M1) — é o handler padrão do Express, camada diferente desta.
