### PR TITLE
Origem do CORS explícita e configurável, com aviso para '*' (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Um exemplo de `configuracao.delprops` para um projeto em Delégua:
 liquido.arquetipo = 'rest'
 liquido.linguagem = 'delegua'
 liquido.roteador.cors = verdadeiro
-liquido.roteador.corsOrigem = '*'
+liquido.roteador.origensCors = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro
@@ -230,7 +230,7 @@ Para usar Pituguês, basta alterar a propriedade `linguagem`:
 liquido.arquetipo = 'rest'
 liquido.linguagem = 'pituguês'
 liquido.roteador.cors = verdadeiro
-liquido.roteador.corsOrigem = '*'
+liquido.roteador.origensCors = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro
@@ -239,7 +239,7 @@ liquido.roteador.json = verdadeiro
 liquido.roteador.helmet = verdadeiro
 ```
 
-A propriedade `liquido.roteador.corsOrigem` define a(s) origem(ns) permitida(s) para CORS, separadas por vírgula (por exemplo, `'https://meusite.com.br, https://admin.meusite.com.br'`). O valor `'*'` libera qualquer origem e é adequado apenas para desenvolvimento — em produção, restrinja para o(s) domínio(s) da aplicação. Quando o CORS está habilitado com `'*'`, Liquido exibe um aviso na inicialização.
+A propriedade `liquido.roteador.origensCors` define a(s) origem(ns) permitida(s) para CORS, separadas por vírgula (por exemplo, `'https://meusite.com.br, https://admin.meusite.com.br'`). O valor `'*'` libera qualquer origem e é adequado apenas para desenvolvimento — em produção, restrinja para o(s) domínio(s) da aplicação. Quando o CORS está habilitado com `'*'`, Liquido exibe um aviso na inicialização.
 
 ### Servindo arquivos estáticos
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Um exemplo de `configuracao.delprops` para um projeto em Delégua:
 liquido.arquetipo = 'rest'
 liquido.linguagem = 'delegua'
 liquido.roteador.cors = verdadeiro
+liquido.roteador.corsOrigem = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro
@@ -229,6 +230,7 @@ Para usar Pituguês, basta alterar a propriedade `linguagem`:
 liquido.arquetipo = 'rest'
 liquido.linguagem = 'pituguês'
 liquido.roteador.cors = verdadeiro
+liquido.roteador.corsOrigem = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro
@@ -236,6 +238,8 @@ liquido.roteador.passport = falso
 liquido.roteador.json = verdadeiro
 liquido.roteador.helmet = verdadeiro
 ```
+
+A propriedade `liquido.roteador.corsOrigem` define a(s) origem(ns) permitida(s) para CORS, separadas por vírgula (por exemplo, `'https://meusite.com.br, https://admin.meusite.com.br'`). O valor `'*'` libera qualquer origem e é adequado apenas para desenvolvimento — em produção, restrinja para o(s) domínio(s) da aplicação. Quando o CORS está habilitado com `'*'`, Liquido exibe um aviso na inicialização.
 
 ### Servindo arquivos estáticos
 

--- a/configuracao.delprops
+++ b/configuracao.delprops
@@ -4,6 +4,9 @@ liquido.roteador.diretorioEstatico = 'publico'
 
 // Configuração do roteador.
 liquido.roteador.cors = verdadeiro
+// CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
+// Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
+liquido.roteador.corsOrigem = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/configuracao.delprops
+++ b/configuracao.delprops
@@ -6,7 +6,7 @@ liquido.roteador.diretorioEstatico = 'publico'
 liquido.roteador.cors = verdadeiro
 // CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
 // Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
-liquido.roteador.corsOrigem = '*'
+liquido.roteador.origensCors = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/delprops/roteador.ts
+++ b/fontes/delprops/roteador.ts
@@ -16,6 +16,14 @@ const roteador: DefinicaoPropriedade[] = [
         detalhe: 'Habilita CORS (padrão: falso).',
     },
     {
+        nome: 'corsOrigem',
+        tipo: 'texto',
+        detalhe:
+            "Origem(ns) permitida(s) para CORS, separadas por vírgula. " +
+            "O padrão '*' libera qualquer origem e é adequado apenas para desenvolvimento; " +
+            "em produção, restrinja para o(s) domínio(s) da aplicação.",
+    },
+    {
         nome: 'bodyParser',
         tipo: 'logico',
         detalhe: 'Habilita o body-parser (padrão: verdadeiro).',

--- a/fontes/delprops/roteador.ts
+++ b/fontes/delprops/roteador.ts
@@ -16,7 +16,7 @@ const roteador: DefinicaoPropriedade[] = [
         detalhe: 'Habilita CORS (padrão: falso).',
     },
     {
-        nome: 'corsOrigem',
+        nome: 'origensCors',
         tipo: 'texto',
         detalhe:
             "Origem(ns) permitida(s) para CORS, separadas por vírgula. " +

--- a/fontes/infraestrutura/centro-configuracoes/configuracao-roteador.ts
+++ b/fontes/infraestrutura/centro-configuracoes/configuracao-roteador.ts
@@ -4,7 +4,7 @@ import { ConfiguracaoComum } from "./configuracao-comum";
 export class ConfiguracaoRoteador extends ConfiguracaoComum {
     diretorioEstatico: string = 'publico';
     cors: boolean = false;
-    corsOrigem: string = '*';
+    origensCors: string = '*';
     bodyParser: boolean = true;
     morgan: boolean = false;
     cookieParser: boolean = true;
@@ -21,7 +21,7 @@ export class ConfiguracaoRoteador extends ConfiguracaoComum {
         const roteador = componentes['roteador'] as RoteadorInterface;
         roteador.ativarDesativarBodyParser(this.bodyParser);
         roteador.ativarDesativarCors(this.cors);
-        roteador.configurarOrigemCors(this.corsOrigem);
+        roteador.configurarOrigensCors(this.origensCors);
         roteador.ativarDesativarCookieParser(this.cookieParser);
         roteador.ativarDesativarExpressJson(this.json);
         roteador.ativarDesativarHelmet(this.helmet);

--- a/fontes/infraestrutura/centro-configuracoes/configuracao-roteador.ts
+++ b/fontes/infraestrutura/centro-configuracoes/configuracao-roteador.ts
@@ -4,6 +4,7 @@ import { ConfiguracaoComum } from "./configuracao-comum";
 export class ConfiguracaoRoteador extends ConfiguracaoComum {
     diretorioEstatico: string = 'publico';
     cors: boolean = false;
+    corsOrigem: string = '*';
     bodyParser: boolean = true;
     morgan: boolean = false;
     cookieParser: boolean = true;
@@ -20,6 +21,7 @@ export class ConfiguracaoRoteador extends ConfiguracaoComum {
         const roteador = componentes['roteador'] as RoteadorInterface;
         roteador.ativarDesativarBodyParser(this.bodyParser);
         roteador.ativarDesativarCors(this.cors);
+        roteador.configurarOrigemCors(this.corsOrigem);
         roteador.ativarDesativarCookieParser(this.cookieParser);
         roteador.ativarDesativarExpressJson(this.json);
         roteador.ativarDesativarHelmet(this.helmet);

--- a/fontes/infraestrutura/roteador/roteador.ts
+++ b/fontes/infraestrutura/roteador/roteador.ts
@@ -32,7 +32,7 @@ export class Roteador implements RoteadorInterface {
     bodyParser = false;
 
     cors = false;
-    corsOrigem = '*';
+    origensCors = '*';
     passport = false;
 
     constructor(autoDocumentador: AutoDocumentador) {
@@ -128,7 +128,7 @@ export class Roteador implements RoteadorInterface {
                 console.log(
                     "[Liquido] CORS habilitado para qualquer origem ('*'). " +
                     "Adequado apenas para desenvolvimento; em produção, restrinja com " +
-                    "liquido.roteador.corsOrigem = 'https://seudominio.com.br' em configuracao.delprops."
+                    "liquido.roteador.origensCors = 'https://seudominio.com.br' em configuracao.delprops."
                 );
                 this.aplicacao.use(cors());
             } else {
@@ -154,22 +154,22 @@ export class Roteador implements RoteadorInterface {
      * ou várias separadas por vírgula. O valor '*' (padrão) libera qualquer
      * origem e deve ser usado apenas em desenvolvimento.
      */
-    configurarOrigemCors(origem: string): void {
-        this.corsOrigem = origem && origem.trim().length > 0 ? origem : '*';
+    configurarOrigensCors(origem: string): void {
+        this.origensCors = origem && origem.trim().length > 0 ? origem : '*';
     }
 
     /**
-     * Traduz `corsOrigem` para as opções do middleware `cors`.
+     * Traduz `origensCors` para as opções do middleware `cors`.
      * @returns `undefined` quando a origem é '*' (comportamento padrão do
      *          middleware, que libera qualquer origem), ou um objeto com a
      *          lista de origens permitidas.
      */
     resolverOpcoesCors(): { origin: string[] } | undefined {
-        if (this.corsOrigem === '*') {
+        if (this.origensCors === '*') {
             return undefined;
         }
 
-        const origens = this.corsOrigem
+        const origens = this.origensCors
             .split(',')
             .map(origem => origem.trim())
             .filter(origem => origem.length > 0);

--- a/fontes/infraestrutura/roteador/roteador.ts
+++ b/fontes/infraestrutura/roteador/roteador.ts
@@ -32,6 +32,7 @@ export class Roteador implements RoteadorInterface {
     bodyParser = false;
 
     cors = false;
+    corsOrigem = '*';
     passport = false;
 
     constructor(autoDocumentador: AutoDocumentador) {
@@ -122,7 +123,17 @@ export class Roteador implements RoteadorInterface {
         }
 
         if (this.cors) {
-            this.aplicacao.use(cors());
+            const opcoesCors = this.resolverOpcoesCors();
+            if (opcoesCors === undefined) {
+                console.log(
+                    "[Liquido] CORS habilitado para qualquer origem ('*'). " +
+                    "Adequado apenas para desenvolvimento; em produção, restrinja com " +
+                    "liquido.roteador.corsOrigem = 'https://seudominio.com.br' em configuracao.delprops."
+                );
+                this.aplicacao.use(cors());
+            } else {
+                this.aplicacao.use(cors(opcoesCors));
+            }
         }
 
         if (this.passport) {
@@ -136,6 +147,38 @@ export class Roteador implements RoteadorInterface {
 
     ativarDesativarCors(valor: boolean): void {
         this.cors = valor;
+    }
+
+    /**
+     * Define a(s) origem(ns) permitida(s) para CORS. Aceita uma única origem
+     * ou várias separadas por vírgula. O valor '*' (padrão) libera qualquer
+     * origem e deve ser usado apenas em desenvolvimento.
+     */
+    configurarOrigemCors(origem: string): void {
+        this.corsOrigem = origem && origem.trim().length > 0 ? origem : '*';
+    }
+
+    /**
+     * Traduz `corsOrigem` para as opções do middleware `cors`.
+     * @returns `undefined` quando a origem é '*' (comportamento padrão do
+     *          middleware, que libera qualquer origem), ou um objeto com a
+     *          lista de origens permitidas.
+     */
+    resolverOpcoesCors(): { origin: string[] } | undefined {
+        if (this.corsOrigem === '*') {
+            return undefined;
+        }
+
+        const origens = this.corsOrigem
+            .split(',')
+            .map(origem => origem.trim())
+            .filter(origem => origem.length > 0);
+
+        if (origens.length === 0) {
+            return undefined;
+        }
+
+        return { origin: origens };
     }
 
     ativarDesativarPassport(valor: boolean): void {

--- a/fontes/interface-linha-comando/exemplos/delegua/api-rest/configuracao.delprops
+++ b/fontes/interface-linha-comando/exemplos/delegua/api-rest/configuracao.delprops
@@ -14,7 +14,7 @@ liquido.roteador.diretorioEstatico = 'publico'
 liquido.roteador.cors = verdadeiro
 // CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
 // Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
-liquido.roteador.corsOrigem = '*'
+liquido.roteador.origensCors = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/interface-linha-comando/exemplos/delegua/api-rest/configuracao.delprops
+++ b/fontes/interface-linha-comando/exemplos/delegua/api-rest/configuracao.delprops
@@ -12,6 +12,9 @@ liquido.roteador.diretorioEstatico = 'publico'
 
 // Configuração do roteador.
 liquido.roteador.cors = verdadeiro
+// CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
+// Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
+liquido.roteador.corsOrigem = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/interface-linha-comando/exemplos/delegua/mvc/configuracao.delprops
+++ b/fontes/interface-linha-comando/exemplos/delegua/mvc/configuracao.delprops
@@ -14,7 +14,7 @@ liquido.roteador.diretorioEstatico = 'publico'
 liquido.roteador.cors = verdadeiro
 // CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
 // Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
-liquido.roteador.corsOrigem = '*'
+liquido.roteador.origensCors = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/interface-linha-comando/exemplos/delegua/mvc/configuracao.delprops
+++ b/fontes/interface-linha-comando/exemplos/delegua/mvc/configuracao.delprops
@@ -12,6 +12,9 @@ liquido.roteador.diretorioEstatico = 'publico'
 
 // Configuração do roteador.
 liquido.roteador.cors = verdadeiro
+// CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
+// Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
+liquido.roteador.corsOrigem = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/interface-linha-comando/exemplos/pitugues/api-rest/configuracao.delprops
+++ b/fontes/interface-linha-comando/exemplos/pitugues/api-rest/configuracao.delprops
@@ -14,7 +14,7 @@ liquido.roteador.diretorioEstatico = 'publico'
 liquido.roteador.cors = verdadeiro
 // CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
 // Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
-liquido.roteador.corsOrigem = '*'
+liquido.roteador.origensCors = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/interface-linha-comando/exemplos/pitugues/api-rest/configuracao.delprops
+++ b/fontes/interface-linha-comando/exemplos/pitugues/api-rest/configuracao.delprops
@@ -12,6 +12,9 @@ liquido.roteador.diretorioEstatico = 'publico'
 
 // Configuração do roteador.
 liquido.roteador.cors = verdadeiro
+// CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
+// Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
+liquido.roteador.corsOrigem = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/interface-linha-comando/exemplos/pitugues/mvc/configuracao.delprops
+++ b/fontes/interface-linha-comando/exemplos/pitugues/mvc/configuracao.delprops
@@ -14,7 +14,7 @@ liquido.roteador.diretorioEstatico = 'publico'
 liquido.roteador.cors = verdadeiro
 // CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
 // Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
-liquido.roteador.corsOrigem = '*'
+liquido.roteador.origensCors = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/interface-linha-comando/exemplos/pitugues/mvc/configuracao.delprops
+++ b/fontes/interface-linha-comando/exemplos/pitugues/mvc/configuracao.delprops
@@ -12,6 +12,9 @@ liquido.roteador.diretorioEstatico = 'publico'
 
 // Configuração do roteador.
 liquido.roteador.cors = verdadeiro
+// CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
+// Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
+liquido.roteador.corsOrigem = '*'
 liquido.roteador.bodyParser = verdadeiro
 liquido.roteador.morgan = verdadeiro
 liquido.roteador.cookieParser = verdadeiro

--- a/fontes/interfaces/roteador-interface.ts
+++ b/fontes/interfaces/roteador-interface.ts
@@ -1,5 +1,6 @@
 export interface RoteadorInterface {
     ativarDesativarCors(valor: boolean): void;
+    configurarOrigemCors(origem: string): void;
     ativarDesativarPassport(valor: boolean): void;
     ativarDesativarCookieParser(valor: boolean): void;
     ativarDesativarExpressJson(valor: boolean): void;

--- a/fontes/interfaces/roteador-interface.ts
+++ b/fontes/interfaces/roteador-interface.ts
@@ -1,6 +1,6 @@
 export interface RoteadorInterface {
     ativarDesativarCors(valor: boolean): void;
-    configurarOrigemCors(origem: string): void;
+    configurarOrigensCors(origem: string): void;
     ativarDesativarPassport(valor: boolean): void;
     ativarDesativarCookieParser(valor: boolean): void;
     ativarDesativarExpressJson(valor: boolean): void;

--- a/testes/infraestrutura/centro-configuracoes.test.ts
+++ b/testes/infraestrutura/centro-configuracoes.test.ts
@@ -174,7 +174,7 @@ describe('Testes das classes de configuração', () => {
             const roteador = {
                 ativarDesativarBodyParser: jest.fn(),
                 ativarDesativarCors: jest.fn(),
-                configurarOrigemCors: jest.fn(),
+                configurarOrigensCors: jest.fn(),
                 ativarDesativarCookieParser: jest.fn(),
                 ativarDesativarExpressJson: jest.fn(),
                 ativarDesativarHelmet: jest.fn(),
@@ -185,7 +185,7 @@ describe('Testes das classes de configuração', () => {
             config.configurar({ roteador });
             expect(roteador.ativarDesativarBodyParser).toHaveBeenCalledWith(true);
             expect(roteador.ativarDesativarCors).toHaveBeenCalledWith(false);
-            expect(roteador.configurarOrigemCors).toHaveBeenCalledWith('*');
+            expect(roteador.configurarOrigensCors).toHaveBeenCalledWith('*');
             expect(roteador.ativarDesativarCookieParser).toHaveBeenCalledWith(true);
             expect(roteador.ativarDesativarExpressJson).toHaveBeenCalledWith(true);
             expect(roteador.ativarDesativarHelmet).toHaveBeenCalledWith(true);
@@ -200,7 +200,7 @@ describe('Testes das classes de configuração', () => {
             const roteador = {
                 ativarDesativarBodyParser: jest.fn(),
                 ativarDesativarCors: jest.fn(),
-                configurarOrigemCors: jest.fn(),
+                configurarOrigensCors: jest.fn(),
                 ativarDesativarCookieParser: jest.fn(),
                 ativarDesativarExpressJson: jest.fn(),
                 ativarDesativarHelmet: jest.fn(),
@@ -285,7 +285,7 @@ describe('Testes das classes de configuração', () => {
             const roteador = {
                 ativarDesativarBodyParser: jest.fn(),
                 ativarDesativarCors: jest.fn(),
-                configurarOrigemCors: jest.fn(),
+                configurarOrigensCors: jest.fn(),
                 ativarDesativarCookieParser: jest.fn(),
                 ativarDesativarExpressJson: jest.fn(),
                 ativarDesativarHelmet: jest.fn(),

--- a/testes/infraestrutura/centro-configuracoes.test.ts
+++ b/testes/infraestrutura/centro-configuracoes.test.ts
@@ -174,6 +174,7 @@ describe('Testes das classes de configuração', () => {
             const roteador = {
                 ativarDesativarBodyParser: jest.fn(),
                 ativarDesativarCors: jest.fn(),
+                configurarOrigemCors: jest.fn(),
                 ativarDesativarCookieParser: jest.fn(),
                 ativarDesativarExpressJson: jest.fn(),
                 ativarDesativarHelmet: jest.fn(),
@@ -184,6 +185,7 @@ describe('Testes das classes de configuração', () => {
             config.configurar({ roteador });
             expect(roteador.ativarDesativarBodyParser).toHaveBeenCalledWith(true);
             expect(roteador.ativarDesativarCors).toHaveBeenCalledWith(false);
+            expect(roteador.configurarOrigemCors).toHaveBeenCalledWith('*');
             expect(roteador.ativarDesativarCookieParser).toHaveBeenCalledWith(true);
             expect(roteador.ativarDesativarExpressJson).toHaveBeenCalledWith(true);
             expect(roteador.ativarDesativarHelmet).toHaveBeenCalledWith(true);
@@ -198,6 +200,7 @@ describe('Testes das classes de configuração', () => {
             const roteador = {
                 ativarDesativarBodyParser: jest.fn(),
                 ativarDesativarCors: jest.fn(),
+                configurarOrigemCors: jest.fn(),
                 ativarDesativarCookieParser: jest.fn(),
                 ativarDesativarExpressJson: jest.fn(),
                 ativarDesativarHelmet: jest.fn(),
@@ -282,6 +285,7 @@ describe('Testes das classes de configuração', () => {
             const roteador = {
                 ativarDesativarBodyParser: jest.fn(),
                 ativarDesativarCors: jest.fn(),
+                configurarOrigemCors: jest.fn(),
                 ativarDesativarCookieParser: jest.fn(),
                 ativarDesativarExpressJson: jest.fn(),
                 ativarDesativarHelmet: jest.fn(),

--- a/testes/infraestrutura/cors-origem.test.ts
+++ b/testes/infraestrutura/cors-origem.test.ts
@@ -1,0 +1,139 @@
+import { Roteador } from '../../fontes/infraestrutura/roteador/roteador';
+import { ConfiguracaoRoteador } from '../../fontes/infraestrutura/centro-configuracoes/configuracao-roteador';
+import { AutoDocumentador } from '../../fontes/infraestrutura/auto-documentacao/auto-documentador';
+
+/**
+ * Testes de regressão para o achado B4 (issue #119):
+ * a origem do CORS deve ser explícita e configurável por
+ * `liquido.roteador.corsOrigem`, com aviso quando liberada para
+ * qualquer origem ('*').
+ */
+describe('CORS com origem configurável', () => {
+    const criarRoteador = (): Roteador => new Roteador(new AutoDocumentador());
+
+    describe('Roteador.resolverOpcoesCors', () => {
+        it("padrão '*' resolve para undefined (comportamento liberado do middleware)", () => {
+            const roteador = criarRoteador();
+            expect(roteador.resolverOpcoesCors()).toBeUndefined();
+        });
+
+        it('uma origem única resolve para lista com um item', () => {
+            const roteador = criarRoteador();
+            roteador.configurarOrigemCors('https://meusite.com.br');
+            expect(roteador.resolverOpcoesCors()).toEqual({
+                origin: ['https://meusite.com.br']
+            });
+        });
+
+        it('múltiplas origens separadas por vírgula resolvem para lista, ignorando espaços', () => {
+            const roteador = criarRoteador();
+            roteador.configurarOrigemCors('https://a.com.br, https://b.com.br ,https://c.com.br');
+            expect(roteador.resolverOpcoesCors()).toEqual({
+                origin: ['https://a.com.br', 'https://b.com.br', 'https://c.com.br']
+            });
+        });
+
+        it('valor vazio ou apenas vírgulas volta ao comportamento padrão', () => {
+            const roteador = criarRoteador();
+            roteador.configurarOrigemCors('');
+            expect(roteador.resolverOpcoesCors()).toBeUndefined();
+
+            roteador.configurarOrigemCors(' , ,');
+            expect(roteador.resolverOpcoesCors()).toBeUndefined();
+        });
+    });
+
+    describe('Aviso de desenvolvimento na inicialização', () => {
+        let espiaoConsole: jest.SpyInstance;
+
+        beforeEach(() => {
+            espiaoConsole = jest.spyOn(console, 'log').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            espiaoConsole.mockRestore();
+        });
+
+        const saidaConsole = (): string =>
+            espiaoConsole.mock.calls.map((chamada) => String(chamada[0])).join('\n');
+
+        it("deve avisar quando CORS está habilitado com origem '*'", () => {
+            const roteador = criarRoteador();
+            roteador.ativarDesativarCors(true);
+            roteador.iniciarMiddlewares();
+
+            expect(saidaConsole()).toContain("CORS habilitado para qualquer origem ('*')");
+            expect(saidaConsole()).toContain('apenas para desenvolvimento');
+        });
+
+        it('não deve avisar quando a origem está restringida', () => {
+            const roteador = criarRoteador();
+            roteador.ativarDesativarCors(true);
+            roteador.configurarOrigemCors('https://meusite.com.br');
+            roteador.iniciarMiddlewares();
+
+            expect(saidaConsole()).not.toContain('CORS habilitado para qualquer origem');
+        });
+
+        it('não deve avisar quando CORS está desabilitado', () => {
+            const roteador = criarRoteador();
+            roteador.iniciarMiddlewares();
+
+            expect(saidaConsole()).not.toContain('CORS habilitado para qualquer origem');
+        });
+    });
+
+    describe('ConfiguracaoRoteador', () => {
+        it("deve ter '*' como padrão de corsOrigem", () => {
+            const configuracao = new ConfiguracaoRoteador();
+            expect(configuracao.corsOrigem).toBe('*');
+        });
+
+        it('deve repassar corsOrigem ao roteador em configurar()', () => {
+            const configuracao = new ConfiguracaoRoteador({
+                cors: true,
+                corsOrigem: 'https://meusite.com.br'
+            });
+
+            const roteadorSimulado = {
+                ativarDesativarBodyParser: jest.fn(),
+                ativarDesativarCors: jest.fn(),
+                configurarOrigemCors: jest.fn(),
+                ativarDesativarCookieParser: jest.fn(),
+                ativarDesativarExpressJson: jest.fn(),
+                ativarDesativarHelmet: jest.fn(),
+                ativarDesativarMorgan: jest.fn(),
+                ativarDesativarPassport: jest.fn()
+            };
+
+            configuracao.configurar({ roteador: roteadorSimulado });
+
+            expect(roteadorSimulado.ativarDesativarCors).toHaveBeenCalledWith(true);
+            expect(roteadorSimulado.configurarOrigemCors).toHaveBeenCalledWith('https://meusite.com.br');
+        });
+    });
+
+    describe('Templates do scaffold', () => {
+        it.each([
+            ['delegua/api-rest'],
+            ['delegua/mvc'],
+            ['pitugues/api-rest'],
+            ['pitugues/mvc']
+        ])('template %s deve declarar corsOrigem explicitamente com aviso', (template: string) => {
+            const sistemaArquivos = require('fs');
+            const caminho = require('path');
+            const conteudo = sistemaArquivos.readFileSync(
+                caminho.join(
+                    __dirname,
+                    '../../fontes/interface-linha-comando/exemplos',
+                    template,
+                    'configuracao.delprops'
+                ),
+                'utf-8'
+            );
+
+            expect(conteudo).toContain("liquido.roteador.corsOrigem = '*'");
+            expect(conteudo).toContain('apenas para desenvolvimento');
+        });
+    });
+});

--- a/testes/infraestrutura/cors-origem.test.ts
+++ b/testes/infraestrutura/cors-origem.test.ts
@@ -5,7 +5,7 @@ import { AutoDocumentador } from '../../fontes/infraestrutura/auto-documentacao/
 /**
  * Testes de regressão para o achado B4 (issue #119):
  * a origem do CORS deve ser explícita e configurável por
- * `liquido.roteador.corsOrigem`, com aviso quando liberada para
+ * `liquido.roteador.origensCors`, com aviso quando liberada para
  * qualquer origem ('*').
  */
 describe('CORS com origem configurável', () => {
@@ -19,7 +19,7 @@ describe('CORS com origem configurável', () => {
 
         it('uma origem única resolve para lista com um item', () => {
             const roteador = criarRoteador();
-            roteador.configurarOrigemCors('https://meusite.com.br');
+            roteador.configurarOrigensCors('https://meusite.com.br');
             expect(roteador.resolverOpcoesCors()).toEqual({
                 origin: ['https://meusite.com.br']
             });
@@ -27,7 +27,7 @@ describe('CORS com origem configurável', () => {
 
         it('múltiplas origens separadas por vírgula resolvem para lista, ignorando espaços', () => {
             const roteador = criarRoteador();
-            roteador.configurarOrigemCors('https://a.com.br, https://b.com.br ,https://c.com.br');
+            roteador.configurarOrigensCors('https://a.com.br, https://b.com.br ,https://c.com.br');
             expect(roteador.resolverOpcoesCors()).toEqual({
                 origin: ['https://a.com.br', 'https://b.com.br', 'https://c.com.br']
             });
@@ -35,10 +35,10 @@ describe('CORS com origem configurável', () => {
 
         it('valor vazio ou apenas vírgulas volta ao comportamento padrão', () => {
             const roteador = criarRoteador();
-            roteador.configurarOrigemCors('');
+            roteador.configurarOrigensCors('');
             expect(roteador.resolverOpcoesCors()).toBeUndefined();
 
-            roteador.configurarOrigemCors(' , ,');
+            roteador.configurarOrigensCors(' , ,');
             expect(roteador.resolverOpcoesCors()).toBeUndefined();
         });
     });
@@ -69,7 +69,7 @@ describe('CORS com origem configurável', () => {
         it('não deve avisar quando a origem está restringida', () => {
             const roteador = criarRoteador();
             roteador.ativarDesativarCors(true);
-            roteador.configurarOrigemCors('https://meusite.com.br');
+            roteador.configurarOrigensCors('https://meusite.com.br');
             roteador.iniciarMiddlewares();
 
             expect(saidaConsole()).not.toContain('CORS habilitado para qualquer origem');
@@ -84,21 +84,21 @@ describe('CORS com origem configurável', () => {
     });
 
     describe('ConfiguracaoRoteador', () => {
-        it("deve ter '*' como padrão de corsOrigem", () => {
+        it("deve ter '*' como padrão de origensCors", () => {
             const configuracao = new ConfiguracaoRoteador();
-            expect(configuracao.corsOrigem).toBe('*');
+            expect(configuracao.origensCors).toBe('*');
         });
 
-        it('deve repassar corsOrigem ao roteador em configurar()', () => {
+        it('deve repassar origensCors ao roteador em configurar()', () => {
             const configuracao = new ConfiguracaoRoteador({
                 cors: true,
-                corsOrigem: 'https://meusite.com.br'
+                origensCors: 'https://meusite.com.br'
             });
 
             const roteadorSimulado = {
                 ativarDesativarBodyParser: jest.fn(),
                 ativarDesativarCors: jest.fn(),
-                configurarOrigemCors: jest.fn(),
+                configurarOrigensCors: jest.fn(),
                 ativarDesativarCookieParser: jest.fn(),
                 ativarDesativarExpressJson: jest.fn(),
                 ativarDesativarHelmet: jest.fn(),
@@ -109,7 +109,7 @@ describe('CORS com origem configurável', () => {
             configuracao.configurar({ roteador: roteadorSimulado });
 
             expect(roteadorSimulado.ativarDesativarCors).toHaveBeenCalledWith(true);
-            expect(roteadorSimulado.configurarOrigemCors).toHaveBeenCalledWith('https://meusite.com.br');
+            expect(roteadorSimulado.configurarOrigensCors).toHaveBeenCalledWith('https://meusite.com.br');
         });
     });
 
@@ -119,7 +119,7 @@ describe('CORS com origem configurável', () => {
             ['delegua/mvc'],
             ['pitugues/api-rest'],
             ['pitugues/mvc']
-        ])('template %s deve declarar corsOrigem explicitamente com aviso', (template: string) => {
+        ])('template %s deve declarar origensCors explicitamente com aviso', (template: string) => {
             const sistemaArquivos = require('fs');
             const caminho = require('path');
             const conteudo = sistemaArquivos.readFileSync(
@@ -132,7 +132,7 @@ describe('CORS com origem configurável', () => {
                 'utf-8'
             );
 
-            expect(conteudo).toContain("liquido.roteador.corsOrigem = '*'");
+            expect(conteudo).toContain("liquido.roteador.origensCors = '*'");
             expect(conteudo).toContain('apenas para desenvolvimento');
         });
     });


### PR DESCRIPTION
# Origem do CORS explícita e configurável em `configuracao.delprops`, com aviso para `'*'`

Fixes #119

## Contexto

Atende diretamente à direção apontada no comentário da issue ("Estou querendo colocar isso explicitamente em `configuracao.delprops`"): a origem do CORS agora é uma propriedade declarada, visível e documentada — em vez de um `cors()` sem opções liberando `'*'` de forma invisível.

## O que muda

**Nova propriedade `liquido.roteador.corsOrigem`** (padrão `'*'`):

```js
liquido.roteador.cors = verdadeiro
// CORS liberado para qualquer origem ('*') é adequado apenas para desenvolvimento.
// Em produção, restrinja para o(s) domínio(s) da aplicação, separados por vírgula.
liquido.roteador.corsOrigem = '*'
```

- Aceita origem única (`'https://meusite.com.br'`) ou várias separadas por vírgula;
- Encanada por `ConfiguracaoRoteador` → `RoteadorInterface` → `Roteador`, com a validação natural do centro de configurações e entrada no esquema delprops (com `detalhe` em português);
- `Roteador.resolverOpcoesCors()` traduz o valor para as opções do middleware: `'*'` mantém o comportamento liberado; qualquer outro valor vira `{ origin: [...] }`. Espaços tolerados, itens vazios ignorados, valor vazio volta ao padrão.

**Aviso explícito na inicialização** quando CORS está habilitado com `'*'`:

```
[Liquido] CORS habilitado para qualquer origem ('*'). Adequado apenas para
desenvolvimento; em produção, restrinja com
liquido.roteador.corsOrigem = 'https://seudominio.com.br' em configuracao.delprops.
```

**Templates e documentação**: os 4 templates do scaffold (Delégua/Pituguês × MVC/API REST) e o `configuracao.delprops` do próprio repositório declaram `corsOrigem` explicitamente com o comentário de aviso; README documenta a propriedade nos exemplos de configuração.

## Sobre a segunda parte da issue (`.gitignore`)

**Correção honesta ao relatório de origem**: a geração de `.gitignore` **já existe** na `principal` e no pacote `1.4.0` publicado — `gerarRepositorioGit` escreve um `.gitignore` completo (node_modules, dist, .env*, coverage, logs, .DS_Store etc.) quando o Git é aceito. O achado B4 estava incorreto nesse ponto: nos testes do relatório, a pergunta de Git foi respondida com "não", e o caminho "sim" não foi validado. Nenhuma mudança foi necessária; fica o registro para fechar essa metade da issue como já resolvida.

## Validação de ponta a ponta

Código compilado (`tsc`) sobreposto ao pacote `liquido@1.4.0` instalado, projeto REST real:

| Configuração | Requisição | Resultado |
|---|---|---|
| `corsOrigem = 'https://meusite.com.br'` | `Origin: https://meusite.com.br` | `Access-Control-Allow-Origin: https://meusite.com.br` ✓ |
| `corsOrigem = 'https://meusite.com.br'` | `Origin: https://malicioso.com` | **sem** header (origem bloqueada) ✓ |
| `corsOrigem = 'https://meusite.com.br'` | boot | sem aviso ✓ |
| `corsOrigem = '*'` | `Origin: https://qualquer.com` | `Access-Control-Allow-Origin: *` + aviso em português no boot ✓ |

## Testes

Novo `testes/infraestrutura/cors-origem.test.ts` com **13 casos**: parsing de origens (única, múltiplas com espaços, vazia), aviso condicional na inicialização (com `'*'`, sem com origem restrita, sem com CORS desligado), repasse da configuração ao roteador, valor padrão, e presença da declaração explícita nos 4 templates. Mocks de `centro-configuracoes.test.ts` atualizados para o novo método da interface.

```
Suíte unitária completa: 240 testes passando
npx tsc --noEmit: sem erros
```

## Compatibilidade

Sem quebra: `corsOrigem` tem padrão `'*'`, preservando o comportamento atual de projetos existentes que só definem `cors = verdadeiro` — eles apenas passam a ver o aviso de desenvolvimento no boot, que é o objetivo da issue.
