### PR TITLE
104: adiciona script liquido ao inicializar novo projeto

### DIFF
--- a/fontes/interface-linha-comando/novo/index.ts
+++ b/fontes/interface-linha-comando/novo/index.ts
@@ -133,6 +133,21 @@ export async function detectarGerenciadorDePacotes(
             break;
         }
     }
+    await adicionarScriptsLiquido(caminhoPackageJson);
+}
+
+async function adicionarScriptsLiquido(caminhoPackageJson: string) {
+    const packageJson = JSON.parse(
+        await sistemaArquivos.promises.readFile(caminhoPackageJson, 'utf8')
+    );
+
+    packageJson.scripts ??= {};
+    packageJson.scripts.liquido = 'node ./node_modules/liquido/index.js';
+
+    await sistemaArquivos.promises.writeFile(
+        caminhoPackageJson,
+        JSON.stringify(packageJson, null, 2) + '\n'
+    );
 }
 
 /* export function gerarProjetoPorTipoDeProjeto(tipoDeProjeto: string) {

--- a/testes/liquido.test.ts
+++ b/testes/liquido.test.ts
@@ -306,6 +306,11 @@ describe('Liquido', () => {
                     () => Buffer.from('')
                 );
 
+                await sistemaArquivos.promises.writeFile(
+                        caminho.join(caminhoDiretorioProjeto, 'package.json'),
+                        JSON.stringify({ name: 'teste', scripts: {} })
+                );
+
                 await detectarGerenciadorDePacotes(
                     'npm',
                     caminhoDiretorioProjeto
@@ -319,6 +324,16 @@ describe('Liquido', () => {
                     'npm install liquido@latest',
                     { cwd: caminhoDiretorioProjeto }
                 );
+
+                const conteudoPackageJson = JSON.parse(
+                    await sistemaArquivos.promises.readFile(
+                        caminho.join(caminhoDiretorioProjeto, 'package.json'),
+                        'utf-8'
+                    )
+                );
+                expect(conteudoPackageJson.scripts).toHaveProperty(
+                    'liquido', 'node ./node_modules/liquido/index.js'
+                );
             });
 
 
@@ -327,6 +342,11 @@ describe('Liquido', () => {
 
                 (ChildProcess.execSync as jest.Mock).mockImplementation(
                     () => Buffer.from('')
+                );
+
+                await sistemaArquivos.promises.writeFile(
+                        caminho.join(caminhoDiretorioProjeto, 'package.json'),
+                        JSON.stringify({ name: 'teste', scripts: {} })
                 );
 
                 await detectarGerenciadorDePacotes(
@@ -342,7 +362,16 @@ describe('Liquido', () => {
                     'yarn add liquido@latest',
                     { cwd: caminhoDiretorioProjeto }
                 );
-    
+
+                const conteudoPackageJson = JSON.parse(
+                    await sistemaArquivos.promises.readFile(
+                        caminho.join(caminhoDiretorioProjeto, 'package.json'),
+                        'utf-8'
+                    )
+                );
+                expect(conteudoPackageJson.scripts).toHaveProperty(
+                    'liquido', 'node ./node_modules/liquido/index.js'
+                );
             });
 
             it('Deve inicializar projeto com Bun sem criar arquivos desnecessários', async () => {
@@ -391,6 +420,9 @@ describe('Liquido', () => {
                     });
                     expect(conteudoPackageJson).not.toHaveProperty(
                         'peerDependencies.typescript'
+                    );
+                    expect(conteudoPackageJson.scripts).toHaveProperty(
+                        'liquido', 'node ./node_modules/liquido/index.js'
                     );
                     expect(
                         sistemaArquivos.existsSync(`${caminhoDiretorioBun}/tsconfig.json`)


### PR DESCRIPTION
## O que foi alterado

* Criada a função interna `adicionarScriptsLiquido` no arquivo `fontes/interface-linha-comando/novo/index.ts`.
* Invocação da função `adicionarScriptsLiquido` adicionada ao final da execução de `detectarGerenciadorDePacotes`, garantindo que funcione de forma agnóstica para `npm`, `yarn` e `bun`.
* **Atualização dos Testes:** Ajustados os testes unitários em `testes/liquido.test.ts` para mockar corretamente a criação do arquivo `package.json` e adicionadas asserções para validar que o script `"liquido"` foi escrito com sucesso no arquivo em todos os gerenciadores de pacotes.

## Motivo da mudança

Atualmente, ao criar um novo projeto, o `package.json` gerado não inclui os scripts necessários para executar os comandos do framework localmente.

<img width="428" height="228" alt="antes" src="https://github.com/user-attachments/assets/6c9ba3b8-2f71-47b1-96cc-8b109c8943ac" />

## Resultado

Ao gerar um novo projeto, o `package.json` agora é modificado automaticamente para incluir o script do Liquido:

<img width="509" height="287" alt="depois" src="https://github.com/user-attachments/assets/b3145002-f469-43e2-9120-cf10f683f794" />

## Issue relacionada

Resolve #104